### PR TITLE
feat(hero): add hero layouts with key highlights

### DIFF
--- a/src/classic/components/Hero/Hero.stories.tsx
+++ b/src/classic/components/Hero/Hero.stories.tsx
@@ -20,6 +20,28 @@ Default.args = {
   subtitle: "Free, fast, easy",
   buttonLabel: "Find out if I'm a good fit",
   buttonUrl: "/contact",
+  keyHighlights: [
+    {
+      title: "Key highlight 1",
+      description: "This is a key highlight",
+      url: "/key-highlight-1",
+    },
+    {
+      title: "Key highlight 2",
+      description: "This is another key highlight 1",
+      url: "/key-highlight-2",
+    },
+    {
+      title: "Key highlight 3",
+      description: "This is another key highlight 2",
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    },
+    {
+      title: "Key highlight 4",
+      description: "This is another key highlight 3",
+      url: "/key-highlight-4",
+    },
+  ],
 }
 
 // Side layout

--- a/src/classic/components/Hero/Hero.stories.tsx
+++ b/src/classic/components/Hero/Hero.stories.tsx
@@ -13,7 +13,14 @@ const Template: StoryFn<HeroProps> = (args) => <Hero {...args} />
 
 // Default scenario
 export const Default = Template.bind({})
-Default.args = {}
+Default.args = {
+  variant: "center",
+  backgroundUrl: "https://ohno.isomer.gov.sg/images/hero-banner.png",
+  title: "Easily set up good government websites",
+  subtitle: "Free, fast, easy",
+  buttonLabel: "Find out if I'm a good fit",
+  buttonUrl: "/contact",
+}
 
 // Side layout
 export const SideButton = Template.bind({})
@@ -36,6 +43,114 @@ SideDropdown.args = {
   alignment: "left",
   backgroundColor: "white",
   size: "md",
+  title: "Easily set up good government websites",
+  subtitle: "Free, fast, easy",
+  dropdown: {
+    options: [
+      {
+        title: "Option 1",
+        url: "/option-1",
+      },
+      {
+        title: "Option 2",
+        url: "/option-2",
+      },
+      {
+        title:
+          "Some super long option that it should overflow on small screens",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      },
+    ],
+  },
+}
+
+// Image only layout
+export const Image = Template.bind({})
+Image.args = {
+  variant: "image",
+  backgroundUrl: "https://ohno.isomer.gov.sg/images/hero-banner.png",
+}
+
+export const ImageWithDropdown = Template.bind({})
+ImageWithDropdown.args = {
+  variant: "image",
+  backgroundUrl: "https://ohno.isomer.gov.sg/images/hero-banner.png",
+  dropdown: {
+    options: [
+      {
+        title: "Option 1",
+        url: "/option-1",
+      },
+      {
+        title: "Option 2",
+        url: "/option-2",
+      },
+      {
+        title:
+          "Some super long option that it should overflow on small screens",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      },
+    ],
+  },
+}
+
+// Floating layout
+export const FloatingButton = Template.bind({})
+FloatingButton.args = {
+  variant: "floating",
+  backgroundUrl: "https://ohno.isomer.gov.sg/images/hero-banner.png",
+  alignment: "left",
+  backgroundColor: "white",
+  size: "md",
+  title: "Easily set up good government websites",
+  subtitle: "Free, fast, easy",
+  buttonLabel: "Find out if I'm a good fit",
+  buttonUrl: "/contact",
+}
+
+export const FloatingDropdown = Template.bind({})
+FloatingDropdown.args = {
+  variant: "floating",
+  backgroundUrl: "https://ohno.isomer.gov.sg/images/hero-banner.png",
+  alignment: "left",
+  backgroundColor: "white",
+  size: "md",
+  title: "Easily set up good government websites",
+  subtitle: "Free, fast, easy",
+  dropdown: {
+    options: [
+      {
+        title: "Option 1",
+        url: "/option-1",
+      },
+      {
+        title: "Option 2",
+        url: "/option-2",
+      },
+      {
+        title:
+          "Some super long option that it should overflow on small screens",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      },
+    ],
+  },
+}
+
+// Center/Default layout
+export const CenterButton = Template.bind({})
+CenterButton.args = {
+  variant: "center",
+  backgroundUrl: "https://ohno.isomer.gov.sg/images/hero-banner.png",
+  title: "Easily set up good government websites",
+  subtitle: "Free, fast, easy",
+  buttonLabel: "Find out if I'm a good fit",
+  buttonUrl: "/contact",
+}
+
+export const CenterDropdown = Template.bind({})
+CenterDropdown.args = {
+  variant: "center",
+  backgroundUrl: "https://ohno.isomer.gov.sg/images/hero-banner.png",
   title: "Easily set up good government websites",
   subtitle: "Free, fast, easy",
   dropdown: {

--- a/src/classic/components/Hero/Hero.stories.tsx
+++ b/src/classic/components/Hero/Hero.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryFn } from "@storybook/react"
+import type { StoryFn, Meta } from "@storybook/react"
 import Hero from "./Hero"
 import { HeroProps } from "~/common"
 
@@ -15,13 +15,44 @@ const Template: StoryFn<HeroProps> = (args) => <Hero {...args} />
 export const Default = Template.bind({})
 Default.args = {}
 
-// Custom scenario
-export const CustomCard = Template.bind({})
-CustomCard.args = {
-  heroTitle: "Custom title",
-  heroCaption: "Custom title with some text and other stuff",
-  buttonLabel: "Custom button",
-  buttonUrl: "https://google.com",
-  logoUrl: "https://picsum.photos/200",
-  bgUrl: "https://images.unsplash.com/photo-1561336313-0bd5e0b27ec8",
+// Side layout
+export const SideButton = Template.bind({})
+SideButton.args = {
+  variant: "side",
+  backgroundUrl: "https://ohno.isomer.gov.sg/images/hero-banner.png",
+  alignment: "left",
+  backgroundColor: "white",
+  size: "md",
+  title: "Easily set up good government websites",
+  subtitle: "Free, fast, easy",
+  buttonLabel: "Find out if I'm a good fit",
+  buttonUrl: "/contact",
+}
+
+export const SideDropdown = Template.bind({})
+SideDropdown.args = {
+  variant: "side",
+  backgroundUrl: "https://ohno.isomer.gov.sg/images/hero-banner.png",
+  alignment: "left",
+  backgroundColor: "white",
+  size: "md",
+  title: "Easily set up good government websites",
+  subtitle: "Free, fast, easy",
+  dropdown: {
+    options: [
+      {
+        title: "Option 1",
+        url: "/option-1",
+      },
+      {
+        title: "Option 2",
+        url: "/option-2",
+      },
+      {
+        title:
+          "Some super long option that it should overflow on small screens",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      },
+    ],
+  },
 }

--- a/src/classic/components/Hero/Hero.tsx
+++ b/src/classic/components/Hero/Hero.tsx
@@ -20,12 +20,12 @@ const HeroSide = (props: Omit<HeroSideProps, keyof HeroCommonProps>) => {
   return (
     <div className="grow shrink-0">
       {/* Desktop view 768 above */}
-      <div className="invisible md:visible hidden md:block">
+      <div className="hidden md:block">
         <HeroInfoboxDesktop {...props} />
       </div>
 
       {/* Mobile view below 768 */}
-      <div className="visible md:invisible block md:hidden">
+      <div className="block md:hidden">
         <HeroInfoboxMobile {...props} />
       </div>
     </div>
@@ -56,17 +56,17 @@ const HeroFloating = (
   return (
     <div className="md:p-12">
       {/* Desktop view 1024 above */}
-      <div className="invisible lg:visible hidden lg:block max-w-screen-xl mx-auto my-0">
+      <div className="hidden lg:block max-w-screen-xl mx-auto my-0">
         <HeroInfoboxDesktop {...props} />
       </div>
 
       {/* Tablet view 769 to 1023 */}
-      <div className="invisible md:visible lg:invisible hidden md:block lg:hidden mb-0">
+      <div className="hidden md:block lg:hidden mb-0">
         <HeroInfoboxTablet {...props} />
       </div>
 
       {/* Mobile view below 768 */}
-      <div className="visible md:invisible block md:hidden">
+      <div className="block md:hidden">
         <HeroInfoboxMobile {...props} />
       </div>
     </div>
@@ -89,9 +89,7 @@ const HeroCenter = ({
               {title}
             </h1>
             {subtitle && (
-              <p className="invisible md:visible hidden md:block pb-8 text-xl">
-                {subtitle}
-              </p>
+              <p className="hidden md:block pb-8 text-xl">{subtitle}</p>
             )}
             {dropdown && !buttonLabel && !buttonUrl && (
               <HeroDropdown {...dropdown} />

--- a/src/classic/components/Hero/Hero.tsx
+++ b/src/classic/components/Hero/Hero.tsx
@@ -1,15 +1,30 @@
-import { HeroProps } from "~/common"
+import {
+  type HeroCommonProps,
+  type HeroSideProps,
+  type HeroProps,
+} from "~/common/Hero"
+import { HeroInfobox } from "./HeroInfobox"
 
-export default function Hero({
-  heroTitle,
-  heroCaption,
-  buttonLabel,
-  buttonUrl,
-  bgUrl,
-}: HeroProps) {
+const HeroSide = (props: Omit<HeroSideProps, keyof HeroCommonProps>) => {
   return (
-    <div className="bg-white">
-      <div
+    // TODO: Check if padding top/bottom is correct
+    // Ref: https://github.com/isomerpages/isomerpages-template/blob/next-gen/assets/css/blueprint.css#L9080-L9105
+    <div className="grow shrink-0">
+      <HeroInfobox {...props} />
+    </div>
+  )
+}
+
+export const Hero = (props: HeroProps) => {
+  return (
+    <section
+      className={`flex flex-col items-stretch justify-between bg-cover bg-center bg-no-repeat`}
+      style={{
+        backgroundImage: `url('${props.backgroundUrl}')`,
+      }}
+    >
+      {props.variant === "side" && <HeroSide {...props} />}
+      {/* <div
         className="relative isolate px-6 pt-14 lg:px-8"
         style={{
           background: bgUrl
@@ -51,7 +66,9 @@ export default function Hero({
             )}
           </div>
         </div>
-      </div>
-    </div>
+      </div> */}
+    </section>
   )
 }
+
+export default Hero

--- a/src/classic/components/Hero/Hero.tsx
+++ b/src/classic/components/Hero/Hero.tsx
@@ -118,6 +118,81 @@ const HeroCenter = ({
   )
 }
 
+const HeroKeyHighlights = ({
+  keyHighlights,
+}: Pick<HeroCommonProps, "keyHighlights">) => {
+  if (!keyHighlights || keyHighlights.length === 0) {
+    return null
+  }
+
+  return (
+    <section id="key-highlights" className="p-0 lg:px-6 bg-primary text-white">
+      <div className="mx-auto my-0 relative lg:max-w-[60rem] xl:max-w-[76rem] 2xl:max-w-[84rem]">
+        <div className={`m-0 text-center justify-center flex-none md:flex`}>
+          {keyHighlights
+            .slice(0, 4)
+            .map(
+              ({
+                url: highlightUrl,
+                title: highlightTitle,
+                description: highlightDescription,
+              }) => (
+                <div
+                  className={`transition-colors hover:bg-primaryHover cursor-pointer grow basis-0`}
+                >
+                  <a
+                    href={highlightUrl}
+                    rel={
+                      highlightUrl.startsWith("http")
+                        ? "noopener noreferrer nofollow"
+                        : ""
+                    }
+                    target={highlightUrl.startsWith("http") ? "_blank" : ""}
+                  >
+                    <div className="block px-8 py-5">
+                      {highlightTitle && (
+                        <p className="font-semibold text-white tracking-[0.0125rem] uppercase pt-1">
+                          {highlightTitle}
+                          {highlightUrl.startsWith("http") && (
+                            <>
+                              &ensp;
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                width="20"
+                                height="20"
+                                fill="currentColor"
+                                className="text-2xl -mt-0.5 inline-block"
+                                viewBox="0 0 20 20"
+                              >
+                                <path
+                                  fill-rule="evenodd"
+                                  d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5"
+                                />
+                                <path
+                                  fill-rule="evenodd"
+                                  d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0z"
+                                />
+                              </svg>
+                            </>
+                          )}
+                        </p>
+                      )}
+                      {highlightDescription && (
+                        <p className="color-[#ffffffb3] pb-2">
+                          {highlightDescription}
+                        </p>
+                      )}
+                    </div>
+                  </a>
+                </div>
+              ),
+            )}
+        </div>
+      </div>
+    </section>
+  )
+}
+
 export const Hero = (props: HeroProps) => {
   return (
     <section
@@ -132,6 +207,9 @@ export const Hero = (props: HeroProps) => {
       {props.variant !== "side" &&
         props.variant !== "image" &&
         props.variant !== "floating" && <HeroCenter {...props} />}
+      {props.keyHighlights && (
+        <HeroKeyHighlights keyHighlights={props.keyHighlights} />
+      )}
     </section>
   )
 }

--- a/src/classic/components/Hero/Hero.tsx
+++ b/src/classic/components/Hero/Hero.tsx
@@ -85,7 +85,7 @@ const HeroCenter = ({
       <div className="mx-auto mt-8 mb-0 relative">
         <div className="flex lg:min-h-80 lg:h-96 items-center justify-center">
           <div className="flex-none w-3/4 text-center text-white">
-            <h1 className="text-[5.25rem] leading-[5.25rem] font-bold -tracking-[0.09375rem] m-0 pb-8 text-balance">
+            <h1 className="text-6xl md:text-[5.25rem] md:leading-[5.25rem] font-bold -tracking-[0.09375rem] m-0 pb-8 text-balance">
               {title}
             </h1>
             {subtitle && (

--- a/src/classic/components/Hero/Hero.tsx
+++ b/src/classic/components/Hero/Hero.tsx
@@ -2,15 +2,120 @@ import {
   type HeroCommonProps,
   type HeroSideProps,
   type HeroProps,
+  type HeroCenterProps,
+  type HeroFloatingProps,
+  type HeroImageProps,
 } from "~/common/Hero"
-import { HeroInfobox } from "./HeroInfobox"
+import { HeroDropdown } from "./HeroDropdown"
+import {
+  HeroInfoboxDesktop,
+  HeroInfoboxMobile,
+  HeroInfoboxTablet,
+} from "./HeroInfobox"
+
+const BP_BUTTON_CLASSES =
+  "rounded-none box-content appearance-none items-center border border-solid border-[#f0f0f0] shadow-none inline-flex text-base h-9 justify-center px-3 py-[calc(0.375rem-1px)] relative align-top select-none cursor-pointer text-center whitespace-nowrap focus:outline-none active:outline-none disabled:cursor-not-allowed"
 
 const HeroSide = (props: Omit<HeroSideProps, keyof HeroCommonProps>) => {
   return (
-    // TODO: Check if padding top/bottom is correct
-    // Ref: https://github.com/isomerpages/isomerpages-template/blob/next-gen/assets/css/blueprint.css#L9080-L9105
     <div className="grow shrink-0">
-      <HeroInfobox {...props} />
+      {/* Desktop view 768 above */}
+      <div className="invisible md:visible hidden md:block">
+        <HeroInfoboxDesktop {...props} />
+      </div>
+
+      {/* Mobile view below 768 */}
+      <div className="visible md:invisible block md:hidden">
+        <HeroInfoboxMobile {...props} />
+      </div>
+    </div>
+  )
+}
+
+const HeroImage = ({
+  dropdown,
+}: Omit<HeroImageProps, keyof HeroCommonProps>) => {
+  return (
+    <div className="grow shrink-0 px-6 py-12">
+      <div className="mx-auto mt-8 mb-0">
+        <div className="flex min-h-[398px] w-11/12 md:w-5/6 lg:w-2/3 mx-auto items-center justify-center">
+          {dropdown && (
+            <div className="block basis-0 grow shrink p-3 max-w-full">
+              <HeroDropdown {...dropdown} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const HeroFloating = (
+  props: Omit<HeroFloatingProps, keyof HeroCommonProps>,
+) => {
+  return (
+    <div className="md:p-12">
+      {/* Desktop view 1024 above */}
+      <div className="invisible lg:visible hidden lg:block max-w-screen-xl mx-auto my-0">
+        <HeroInfoboxDesktop {...props} />
+      </div>
+
+      {/* Tablet view 769 to 1023 */}
+      <div className="invisible md:visible lg:invisible hidden md:block lg:hidden mb-0">
+        <HeroInfoboxTablet {...props} />
+      </div>
+
+      {/* Mobile view below 768 */}
+      <div className="visible md:invisible block md:hidden">
+        <HeroInfoboxMobile {...props} />
+      </div>
+    </div>
+  )
+}
+
+const HeroCenter = ({
+  title,
+  subtitle,
+  dropdown,
+  buttonLabel,
+  buttonUrl,
+}: Omit<HeroCenterProps, keyof HeroCommonProps>) => {
+  return (
+    <div className="grow shrink-0 bg-[##00000040] px-6 py-12">
+      <div className="mx-auto mt-8 mb-0 relative">
+        <div className="flex lg:min-h-80 lg:h-96 items-center justify-center">
+          <div className="flex-none w-3/4 text-center text-white">
+            <h1 className="text-[5.25rem] leading-[5.25rem] font-bold -tracking-[0.09375rem] m-0 pb-8 text-balance">
+              {title}
+            </h1>
+            {subtitle && (
+              <p className="invisible md:visible hidden md:block pb-8 text-xl">
+                {subtitle}
+              </p>
+            )}
+            {dropdown && !buttonLabel && !buttonUrl && (
+              <HeroDropdown {...dropdown} />
+            )}
+            {buttonLabel && buttonUrl && !dropdown && (
+              <div>
+                {/* <Button label={buttonLabel} /> */}
+                <a
+                  href={buttonUrl}
+                  rel={
+                    buttonUrl.startsWith("http")
+                      ? "noopener noreferrer nofollow"
+                      : ""
+                  }
+                  target={buttonUrl.startsWith("http") ? "_blank" : ""}
+                  className={`${BP_BUTTON_CLASSES} bg-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
+                >
+                  {buttonLabel}
+                </a>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
     </div>
   )
 }
@@ -24,49 +129,11 @@ export const Hero = (props: HeroProps) => {
       }}
     >
       {props.variant === "side" && <HeroSide {...props} />}
-      {/* <div
-        className="relative isolate px-6 pt-14 lg:px-8"
-        style={{
-          background: bgUrl
-            ? `linear-gradient(rgba(0,0,0,0.3),rgba(0,0,0,0.3)), url(${bgUrl})`
-            : "",
-          backgroundSize: "cover",
-        }}
-      >
-        <div
-          className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
-          aria-hidden="true"
-        ></div>
-        <div className="mx-auto max-w-2xl py-32 sm:py-48 lg:py-56">
-          <div className="text-center">
-            <h1
-              className={`text-4xl font-bold ${
-                bgUrl ? "text-white" : "text-gray-900"
-              } sm:text-6xl`}
-            >
-              {heroTitle || "Supercharge your sites like never before"}
-            </h1>
-            <p
-              className={`mt-6 text-lg leading-8 ${
-                bgUrl ? "text-white" : "text-gray-600"
-              }`}
-            >
-              {heroCaption ||
-                "Isomer Next is here to create fast and beautiful informational static sites. Embrace the power of simplicity combined with creativity now."}
-            </p>
-            {buttonLabel && buttonUrl && (
-              <div className="mt-10 flex items-center justify-center">
-                <a
-                  href={buttonUrl}
-                  className="px-4 py-3 text-sm font-medium shadow-sm bg-primary text-white tracking-wide uppercase"
-                >
-                  {buttonLabel}
-                </a>
-              </div>
-            )}
-          </div>
-        </div>
-      </div> */}
+      {props.variant === "image" && <HeroImage {...props} />}
+      {props.variant === "floating" && <HeroFloating {...props} />}
+      {props.variant !== "side" &&
+        props.variant !== "image" &&
+        props.variant !== "floating" && <HeroCenter {...props} />}
     </section>
   )
 }

--- a/src/classic/components/Hero/HeroDropdown.tsx
+++ b/src/classic/components/Hero/HeroDropdown.tsx
@@ -11,7 +11,7 @@ export const HeroDropdown = ({ title, options }: HeroDropdownProps) => {
     <div className="block relative border-light w-full">
       <div className="w-full">
         <a
-          className={`${BP_BUTTON_CLASSES} flex px-6 py-7 box-border justify-between bg-white border-0 border-b border-solid border-border-light m-auto w-[calc(100%-3rem)] text-xl font-semibold`}
+          className={`${BP_BUTTON_CLASSES} flex px-6 py-7 box-border justify-between bg-white border-0 border-b border-solid border-border-light m-auto w-[calc(100%-3rem)] text-xl text-prose font-semibold`}
           aria-haspopup
           aria-controls="hero-dropdown-menu"
           onClick={() => setIsDropdownOpen(!isDropdownOpen)}
@@ -30,7 +30,7 @@ export const HeroDropdown = ({ title, options }: HeroDropdownProps) => {
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="currentColor"
-              viewBox="0 0 16 16"
+              viewBox="0 0 20 20"
               width="20"
               height="20"
               className="text-2xl -mt-0.5"

--- a/src/classic/components/Hero/HeroDropdown.tsx
+++ b/src/classic/components/Hero/HeroDropdown.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react"
+import { type HeroDropdownProps } from "~/common/Hero"
+
+const BP_BUTTON_CLASSES =
+  "rounded-none box-content appearance-none items-center border border-solid border-[#f0f0f0] shadow-none inline-flex text-base h-9 justify-center px-3 py-[calc(0.375rem-1px)] relative align-top select-none cursor-pointer text-center whitespace-nowrap focus:outline-none active:outline-none disabled:cursor-not-allowed"
+
+export const HeroDropdown = ({ title, options }: HeroDropdownProps) => {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+
+  return (
+    <div className="block relative border-light w-full">
+      <div className="w-full">
+        <a
+          className={`${BP_BUTTON_CLASSES} flex px-6 py-7 box-border justify-between bg-white border-0 border-b border-solid border-border-light m-auto w-[calc(100%-3rem)] text-xl font-semibold`}
+          aria-haspopup
+          aria-controls="hero-dropdown-menu"
+          onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+        >
+          {!!title ? (
+            <span>
+              <p>{title}</p>
+            </span>
+          ) : (
+            <span>
+              <p>I want to...</p>
+            </span>
+          )}
+          <span className="justify-center h-4 w-4">
+            {/* Chevron down */}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              viewBox="0 0 16 16"
+              width="20"
+              height="20"
+              className="text-2xl -mt-0.5"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708"
+              />
+            </svg>
+          </span>
+        </a>
+      </div>
+      <div
+        id="hero-dropdown-menu"
+        role="menu"
+        className={`absolute left-0 min-w-48 pt-0 w-full top-full z-20 text-start ${
+          isDropdownOpen ? "block" : "hidden"
+        }`}
+      >
+        <div className="bg-white rounded-none border border-solid border-border-light py-4 m-auto">
+          {options.map(({ url: optionUrl, title: optionTitle }) => {
+            return (
+              optionUrl &&
+              optionTitle && (
+                <a
+                  className="block relative text-prose hover:text-secondary text-xl px-6 py-3"
+                  href={optionUrl}
+                  rel={
+                    optionUrl.startsWith("http")
+                      ? "noopener noreferrer nofollow"
+                      : ""
+                  }
+                  target={optionUrl.startsWith("http") ? "_blank" : ""}
+                >
+                  {optionTitle}
+                </a>
+              )
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/classic/components/Hero/HeroInfobox.tsx
+++ b/src/classic/components/Hero/HeroInfobox.tsx
@@ -5,10 +5,45 @@ import {
 } from "~/common/Hero"
 import { HeroDropdown } from "./HeroDropdown"
 
+type HeroInfoboxVariants =
+  | HeroSideProps["variant"]
+  | HeroFloatingProps["variant"]
+
 const BP_BUTTON_CLASSES =
   "rounded-none box-content appearance-none items-center border border-solid border-[#f0f0f0] shadow-none inline-flex text-base h-9 justify-center px-3 py-[calc(0.375rem-1px)] relative align-top select-none cursor-pointer text-center whitespace-nowrap focus:outline-none active:outline-none disabled:cursor-not-allowed"
 
-export const HeroInfobox = ({
+const bgColor: {
+  [key in NonNullable<HeroInfoboxProps["backgroundColor"]>]: string
+} = {
+  black: "bg-canvas-inverse",
+  white: "bg-canvas-base",
+  gray: "bg-canvas-translucentGrey",
+}
+
+const textColor: {
+  [key in NonNullable<HeroInfoboxProps["backgroundColor"]>]: string
+} = {
+  black: "text-content-inverse",
+  white: "text-content-base",
+  gray: "text-content-inverse",
+}
+
+const width: {
+  [key in HeroInfoboxVariants]: {
+    [key in NonNullable<HeroInfoboxProps["size"]>]: string
+  }
+} = {
+  side: {
+    sm: "w-min w-1/3 xl:w-1/2",
+    md: "w-1/2",
+  },
+  floating: {
+    sm: "w-1/3",
+    md: "w-1/2",
+  },
+}
+
+export const HeroInfoboxDesktop = ({
   variant,
   title,
   subtitle,
@@ -18,101 +53,92 @@ export const HeroInfobox = ({
   backgroundColor = "white",
   size = "md",
   dropdown,
-}: HeroInfoboxProps & {
-  variant: HeroSideProps["variant"] | HeroFloatingProps["variant"]
-}) => {
-  const bgColor: { [key in typeof backgroundColor]: string } = {
-    black: "bg-canvas-inverse",
-    white: "bg-canvas-base",
-    gray: "bg-canvas-translucentGrey",
-  }
-
-  const textColor: { [key in typeof backgroundColor]: string } = {
-    black: "text-content-inverse",
-    white: "text-content-base",
-    gray: "text-content-inverse",
-  }
-
-  const width: { [key in typeof variant]: { [key in typeof size]: string } } = {
-    side: {
-      sm: "w-min w-1/3 xl:w-1/2",
-      md: "w-1/2",
-    },
-    floating: {
-      sm: "w-1/3",
-      md: "w-1/2",
-    },
-  }
-
+}: HeroInfoboxProps & { variant: HeroInfoboxVariants }) => {
   return (
-    <>
-      {/* Desktop view 768 above */}
-      <div className="invisible md:visible hidden md:block">
+    <div
+      className={`flex ${
+        alignment === "right" ? "justify-end" : "justify-start"
+      }`}
+    >
+      <div
+        className={`flex flex-col p-16 ${bgColor[backgroundColor]} ${width[variant][size]}`}
+      >
         <div
-          className={`flex ${
-            alignment === "right" ? "justify-end" : "justify-start"
-          }`}
+          className={`flex flex-col ${
+            variant === "side" ? "w-full max-w-xl" : null
+          } self-${alignment === "right" ? "start" : "end"}`}
         >
-          <div
-            className={`flex flex-col p-16 ${bgColor[backgroundColor]} ${width[variant][size]}`}
-          >
-            <div
-              className={`flex flex-col ${
-                variant === "side" ? "w-full max-w-xl" : null
-              } self-${alignment === "right" ? "start" : "end"}`}
-            >
-              <div className="flex flex-col mb-8">
-                <h1
-                  className={`mb-4 text-[2.75rem] lg:text-5xl not-italic font-bold leading-[3.5rem] -tracking-[0.0605rem] lg:-tracking-[0.066rem] ${textColor[backgroundColor]}`}
-                >
-                  {title}
-                </h1>
-                {subtitle && (
-                  <p
-                    className={`invisible lg:visible text-lg not-italic font-normal ${textColor[backgroundColor]}`}
-                  >
-                    {subtitle}
-                  </p>
-                )}
-              </div>
-              {dropdown && !buttonLabel && !buttonUrl && (
-                <div className="flex w-full justify-center content-center">
-                  <HeroDropdown {...dropdown} />
-                </div>
-              )}
-              {buttonLabel && buttonUrl && !dropdown && (
-                <div>
-                  {/* <Button label={buttonLabel} /> */}
-                  <a
-                    href={buttonUrl}
-                    rel={
-                      buttonUrl.startsWith("http")
-                        ? "noopener noreferrer nofollow"
-                        : ""
-                    }
-                    target={buttonUrl.startsWith("http") ? "_blank" : ""}
-                    className={`${BP_BUTTON_CLASSES} bg-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
-                  >
-                    {buttonLabel}
-                  </a>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Mobile view below 768 */}
-      <div className="visible md:invisible block md:hidden mb-0 m-auto items-center px-12 py-[6.625rem]">
-        <div
-          className={`flex flex-col flex-none py-8 px-12 m-auto items-center w-3/4 min-w-96 ${bgColor[backgroundColor]}`}
-        >
-          <div className="mb-8 text-center">
+          <div className="flex flex-col mb-8">
             <h1
               className={`mb-4 text-[2.75rem] lg:text-5xl not-italic font-bold leading-[3.5rem] -tracking-[0.0605rem] lg:-tracking-[0.066rem] ${textColor[backgroundColor]}`}
             >
               {title}
             </h1>
+            {subtitle && (
+              <p
+                className={`invisible lg:visible text-lg not-italic font-normal ${textColor[backgroundColor]}`}
+              >
+                {subtitle}
+              </p>
+            )}
+          </div>
+          {dropdown && !buttonLabel && !buttonUrl && (
+            <div className="flex w-full justify-center content-center">
+              <HeroDropdown {...dropdown} />
+            </div>
+          )}
+          {buttonLabel && buttonUrl && !dropdown && (
+            <div>
+              {/* <Button label={buttonLabel} /> */}
+              <a
+                href={buttonUrl}
+                rel={
+                  buttonUrl.startsWith("http")
+                    ? "noopener noreferrer nofollow"
+                    : ""
+                }
+                target={buttonUrl.startsWith("http") ? "_blank" : ""}
+                className={`${BP_BUTTON_CLASSES} bg-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
+              >
+                {buttonLabel}
+              </a>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const HeroInfoboxTablet = ({
+  title,
+  buttonLabel,
+  buttonUrl,
+  alignment,
+  backgroundColor = "white",
+  dropdown,
+}: HeroInfoboxProps) => {
+  // TODO: Tablet view is quite jank but it seems like this was the design previously
+  return (
+    <div className={`p-8 ${bgColor[backgroundColor]}`}>
+      <div
+        className={`flex ${
+          alignment === "right" ? "justify-end" : "justify-start"
+        }`}
+      >
+        <div className="flex flex-col">
+          <div className="mb-8">
+            <h1
+              className={`mb-4 text-[2.75rem] lg:text-5xl not-italic font-bold leading-[3.5rem] -tracking-[0.0605rem] lg:-tracking-[0.066rem] ${textColor[backgroundColor]}`}
+            >
+              {title}
+            </h1>
+          </div>
+          <div
+            className={`flex content-center ${
+              alignment === "right" ? "justify-end" : "justify-start"
+            }`}
+          >
             {dropdown && !buttonLabel && !buttonUrl && (
               <HeroDropdown {...dropdown} />
             )}
@@ -136,6 +162,50 @@ export const HeroInfobox = ({
           </div>
         </div>
       </div>
-    </>
+    </div>
+  )
+}
+
+export const HeroInfoboxMobile = ({
+  title,
+  buttonLabel,
+  buttonUrl,
+  backgroundColor = "white",
+  dropdown,
+}: HeroInfoboxProps) => {
+  return (
+    <div className="mb-0 m-auto items-center px-12 py-[6.625rem]">
+      <div
+        className={`flex flex-col flex-none py-8 px-12 m-auto items-center w-3/4 min-w-96 ${bgColor[backgroundColor]}`}
+      >
+        <div className="mb-8 text-center">
+          <h1
+            className={`mb-4 text-[2.75rem] lg:text-5xl not-italic font-bold leading-[3.5rem] -tracking-[0.0605rem] lg:-tracking-[0.066rem] ${textColor[backgroundColor]}`}
+          >
+            {title}
+          </h1>
+          {dropdown && !buttonLabel && !buttonUrl && (
+            <HeroDropdown {...dropdown} />
+          )}
+          {buttonLabel && buttonUrl && !dropdown && (
+            <div>
+              {/* <Button label={buttonLabel} /> */}
+              <a
+                href={buttonUrl}
+                rel={
+                  buttonUrl.startsWith("http")
+                    ? "noopener noreferrer nofollow"
+                    : ""
+                }
+                target={buttonUrl.startsWith("http") ? "_blank" : ""}
+                className={`${BP_BUTTON_CLASSES} bg-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
+              >
+                {buttonLabel}
+              </a>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
   )
 }

--- a/src/classic/components/Hero/HeroInfobox.tsx
+++ b/src/classic/components/Hero/HeroInfobox.tsx
@@ -43,6 +43,21 @@ const width: {
   },
 }
 
+const padding: {
+  [key in HeroInfoboxVariants]: {
+    [key in NonNullable<HeroInfoboxProps["size"]>]: string
+  }
+} = {
+  side: {
+    sm: "p-16",
+    md: "p-16",
+  },
+  floating: {
+    sm: "p-8 xl:p-16",
+    md: "p-16",
+  },
+}
+
 export const HeroInfoboxDesktop = ({
   variant,
   title,
@@ -61,7 +76,7 @@ export const HeroInfoboxDesktop = ({
       }`}
     >
       <div
-        className={`flex flex-col p-16 ${bgColor[backgroundColor]} ${width[variant][size]}`}
+        className={`flex flex-col ${padding[variant][size]} ${bgColor[backgroundColor]} ${width[variant][size]}`}
       >
         <div
           className={`flex flex-col ${

--- a/src/classic/components/Hero/HeroInfobox.tsx
+++ b/src/classic/components/Hero/HeroInfobox.tsx
@@ -1,0 +1,141 @@
+import {
+  type HeroFloatingProps,
+  type HeroInfoboxProps,
+  type HeroSideProps,
+} from "~/common/Hero"
+import { HeroDropdown } from "./HeroDropdown"
+
+const BP_BUTTON_CLASSES =
+  "rounded-none box-content appearance-none items-center border border-solid border-[#f0f0f0] shadow-none inline-flex text-base h-9 justify-center px-3 py-[calc(0.375rem-1px)] relative align-top select-none cursor-pointer text-center whitespace-nowrap focus:outline-none active:outline-none disabled:cursor-not-allowed"
+
+export const HeroInfobox = ({
+  variant,
+  title,
+  subtitle,
+  buttonLabel,
+  buttonUrl,
+  alignment,
+  backgroundColor = "white",
+  size = "md",
+  dropdown,
+}: HeroInfoboxProps & {
+  variant: HeroSideProps["variant"] | HeroFloatingProps["variant"]
+}) => {
+  const bgColor: { [key in typeof backgroundColor]: string } = {
+    black: "bg-canvas-inverse",
+    white: "bg-canvas-base",
+    gray: "bg-canvas-translucentGrey",
+  }
+
+  const textColor: { [key in typeof backgroundColor]: string } = {
+    black: "text-content-inverse",
+    white: "text-content-base",
+    gray: "text-content-inverse",
+  }
+
+  const width: { [key in typeof variant]: { [key in typeof size]: string } } = {
+    side: {
+      sm: "w-min w-1/3 xl:w-1/2",
+      md: "w-1/2",
+    },
+    floating: {
+      sm: "w-1/3",
+      md: "w-1/2",
+    },
+  }
+
+  return (
+    <>
+      {/* Desktop view 768 above */}
+      <div className="invisible md:visible hidden md:block">
+        <div
+          className={`flex ${
+            alignment === "right" ? "justify-end" : "justify-start"
+          }`}
+        >
+          <div
+            className={`flex flex-col p-16 ${bgColor[backgroundColor]} ${width[variant][size]}`}
+          >
+            <div
+              className={`flex flex-col ${
+                variant === "side" ? "w-full max-w-xl" : null
+              } self-${alignment === "right" ? "start" : "end"}`}
+            >
+              <div className="flex flex-col mb-8">
+                <h1
+                  className={`mb-4 text-[2.75rem] lg:text-5xl not-italic font-bold leading-[3.5rem] -tracking-[0.0605rem] lg:-tracking-[0.066rem] ${textColor[backgroundColor]}`}
+                >
+                  {title}
+                </h1>
+                {subtitle && (
+                  <p
+                    className={`invisible lg:visible text-lg not-italic font-normal ${textColor[backgroundColor]}`}
+                  >
+                    {subtitle}
+                  </p>
+                )}
+              </div>
+              {dropdown && !buttonLabel && !buttonUrl && (
+                <div className="flex w-full justify-center content-center">
+                  <HeroDropdown {...dropdown} />
+                </div>
+              )}
+              {buttonLabel && buttonUrl && !dropdown && (
+                <div>
+                  {/* <Button label={buttonLabel} /> */}
+                  <a
+                    href={buttonUrl}
+                    rel={
+                      buttonUrl.startsWith("http")
+                        ? "noopener noreferrer nofollow"
+                        : ""
+                    }
+                    target={buttonUrl.startsWith("http") ? "_blank" : ""}
+                    className={`${BP_BUTTON_CLASSES} bg-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
+                  >
+                    {buttonLabel}
+                  </a>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile view below 768 */}
+      <div className="visible md:invisible block md:hidden mb-0 m-auto items-center px-12 py-[6.625rem]">
+        <div
+          className={`flex flex-col flex-none py-8 px-12 m-auto items-center w-3/4 min-w-96 ${bgColor[backgroundColor]}`}
+        >
+          <div className="mb-8 text-center">
+            <h1
+              className={`mb-4 text-[2.75rem] lg:text-5xl not-italic font-bold leading-[3.5rem] -tracking-[0.0605rem] lg:-tracking-[0.066rem] ${textColor[backgroundColor]}`}
+            >
+              {title}
+            </h1>
+            {dropdown && !buttonLabel && !buttonUrl && (
+              <HeroDropdown {...dropdown} />
+            )}
+            {buttonLabel && buttonUrl && !dropdown && (
+              <div>
+                {/* <Button label={buttonLabel} /> */}
+                <a
+                  href={buttonUrl}
+                  rel={
+                    buttonUrl.startsWith("http")
+                      ? "noopener noreferrer nofollow"
+                      : ""
+                  }
+                  target={buttonUrl.startsWith("http") ? "_blank" : ""}
+                  className={`${BP_BUTTON_CLASSES} bg-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
+                >
+                  {buttonLabel}
+                </a>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/classic/components/Hero/HeroInfobox.tsx
+++ b/src/classic/components/Hero/HeroInfobox.tsx
@@ -76,7 +76,7 @@ export const HeroInfoboxDesktop = ({
             </h1>
             {subtitle && (
               <p
-                className={`invisible lg:visible text-lg not-italic font-normal ${textColor[backgroundColor]}`}
+                className={`hidden lg:block text-lg not-italic font-normal ${textColor[backgroundColor]}`}
               >
                 {subtitle}
               </p>

--- a/src/classic/components/Masthead/Masthead.tsx
+++ b/src/classic/components/Masthead/Masthead.tsx
@@ -73,7 +73,7 @@ export const Masthead = ({ isStaging }: MastheadProps) => {
         <div
           id="sgds-masthead-content"
           className={`lg:container lg:px-6 px-3 pt-4 pb-8 lg:pt-10 lg:pb-12 ${
-            isMastheadContentVisible ? "visible block" : "invisible hidden"
+            isMastheadContentVisible ? "block" : "hidden"
           }`}
         >
           <div className="grid grid-cols-[1fr] lg:grid-cols-[repeat(auto-fit,_minmax(300px,1fr))] gap-6 lg:gap-40">

--- a/src/common/Hero.ts
+++ b/src/common/Hero.ts
@@ -1,11 +1,64 @@
-export interface HeroProps {
-  sectionIdx?: number
-  logoUrl?: string
-  heroTitle?: string
-  heroCaption?: string
+export interface HeroHeadingProps {
+  title: string
+  subtitle?: string
+}
+
+export interface HeroButtonProps {
   buttonLabel?: string
   buttonUrl?: string
-  bgUrl?: string
 }
+
+export interface HeroKeyHighlightProps {
+  title: string
+  description: string
+  url: string
+}
+
+export interface HeroDropdownProps {
+  title?: string
+  options: Array<{
+    title: string
+    url: string
+  }>
+}
+
+export interface HeroInfoboxProps extends HeroHeadingProps, HeroButtonProps {
+  alignment?: "left" | "right"
+  backgroundColor?: "black" | "white" | "gray"
+  size?: "sm" | "md"
+  dropdown?: HeroDropdownProps
+}
+
+export interface HeroCommonProps {
+  backgroundUrl: string
+  keyHighlights?: Array<HeroKeyHighlightProps>
+}
+
+export interface HeroSideProps extends HeroInfoboxProps, HeroCommonProps {
+  variant: "side"
+}
+
+export interface HeroImageProps extends HeroCommonProps {
+  variant: "image"
+  dropdown?: HeroDropdownProps
+}
+
+export interface HeroFloatingProps extends HeroInfoboxProps, HeroCommonProps {
+  variant: "floating"
+}
+
+export interface HeroCenterProps
+  extends HeroHeadingProps,
+    HeroButtonProps,
+    HeroCommonProps {
+  variant: "center"
+  dropdown?: HeroDropdownProps
+}
+
+export type HeroProps =
+  | HeroSideProps
+  | HeroImageProps
+  | HeroFloatingProps
+  | HeroCenterProps
 
 export default HeroProps

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ export default {
     extend: {
       colors: {
         primary: "#6031b6",
+        primaryHover: "#4b268e",
         secondary: "#4372d6",
         subtitle: "#344054",
         paragraph: "#344054",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,31 @@ export default {
         header: "#2164da",
         subtleLink: "#767676",
         navItems: "#323232",
+        border: {
+          light: "#d6d6d6",
+        },
+        canvas: {
+          base: "#ffffff",
+          inverse: "#000000",
+          translucentGrey: "#00000080",
+        },
+        content: {
+          base: "#344054",
+          body: "#484848",
+          inverse: "#ffffff",
+        },
+        interaction: {
+          hover: "#f9f9f9",
+          linkDefault: "#4372d6",
+          linkHover: "#3a79ff",
+        },
+        stroke: {
+          default: "#d0d5dd",
+        },
+        utility: {
+          themeColor: "var(--color-primary)",
+          secondaryColor: "var(--color-secondary)",
+        },
       },
       fontFamily: {
         sans: ["Lato", "ui-sans-serif", "system-ui"],


### PR DESCRIPTION
References:
- Infobox (mobile): https://github.com/isomerpages/isomerpages-template/blob/next-gen/_includes/homepage/hero/components/hero-infobox-mobile.html
- Infobox (desktop): https://github.com/isomerpages/isomerpages-template/blob/next-gen/_includes/homepage/hero/components/hero-infobox-desktop.html
- Dropdown: https://github.com/isomerpages/isomerpages-template/blob/next-gen/_includes/homepage/hero/components/hero-dropdown.html
- Side layout: https://github.com/isomerpages/isomerpages-template/blob/next-gen/_includes/homepage/hero/hero-side-layout.html
- Hero component: https://github.com/isomerpages/isomerpages-template/blob/next-gen/_includes/homepage/hero.html