### PR TITLE
feat: add theme support to storybook

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -91,20 +91,12 @@ const preview: Preview = {
 }
 
 export const decorators: any = [
-  withThemeByClassName({
-    themes: {
-      light: "light",
-      dark: "dark",
-    },
-    defaultTheme: "light",
-  }),
   withThemeByDataAttribute({
     themes: {
-      light: "light",
-      dark: "dark",
+      "Isomer Classic": "isomer-classic",
+      "Isomer Next": "isomer-next",
     },
-    defaultTheme: "light",
-    attributeName: "data-mode",
+    defaultTheme: "Isomer Next",
   }),
 ]
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,15 @@
 @import url("https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap");
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html[data-theme="isomer-next"] {
+    font-family: "Inter", system-ui, sans-serif;
+  }
+
+  html[data-theme="isomer-classic"] {
+    font-family: "Lato", system-ui, sans-serif;
+  }
+}

--- a/src/templates/classic/components/Button/Button.stories.tsx
+++ b/src/templates/classic/components/Button/Button.stories.tsx
@@ -1,11 +1,16 @@
-import { Meta, StoryFn } from "@storybook/react"
+import type { Meta, StoryFn } from "@storybook/react"
 import Button from "./Button"
-import { ButtonProps } from "~/common"
+import type { ButtonProps } from "~/common"
 
 export default {
   title: "Classic/Components/Button",
   component: Button,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Classic",
+    },
+  },
 } as Meta
 
 // Template for stories

--- a/src/templates/classic/components/Cards/Cards.stories.tsx
+++ b/src/templates/classic/components/Cards/Cards.stories.tsx
@@ -1,11 +1,16 @@
-import { Meta, StoryFn } from "@storybook/react"
+import type { Meta, StoryFn } from "@storybook/react"
 import Cards from "./Cards"
-import { CardsProps } from "~/common"
+import type { CardsProps } from "~/common"
 
 export default {
   title: "Classic/Components/Cards",
   component: Cards,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Classic",
+    },
+  },
 } as Meta
 
 // Template for stories

--- a/src/templates/classic/components/Content/Content.stories.tsx
+++ b/src/templates/classic/components/Content/Content.stories.tsx
@@ -1,13 +1,18 @@
-import { StoryFn, Meta } from "@storybook/react"
+import type { StoryFn, Meta } from "@storybook/react"
 import { encode } from "js-base64"
 
 import Content from "./Content"
-import { ContentProps } from "~/common"
+import type { ContentProps } from "~/common"
 
 export default {
   title: "Classic/Components/Content",
   component: Content,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Classic",
+    },
+  },
 } as Meta
 
 // Template for stories

--- a/src/templates/classic/components/Footer/Footer.stories.tsx
+++ b/src/templates/classic/components/Footer/Footer.stories.tsx
@@ -1,11 +1,16 @@
-import { StoryFn, Meta } from "@storybook/react"
+import type { StoryFn, Meta } from "@storybook/react"
 import Footer from "./Footer"
-import { FooterProps } from "~/common"
+import type { FooterProps } from "~/common"
 
 export default {
   title: "Classic/Components/Footer",
   component: Footer,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Classic",
+    },
+  },
 } as Meta
 
 // Template for stories

--- a/src/templates/classic/components/Header/Header.stories.tsx
+++ b/src/templates/classic/components/Header/Header.stories.tsx
@@ -1,12 +1,17 @@
-import { Meta, StoryFn } from "@storybook/react"
+import type { Meta, StoryFn } from "@storybook/react"
 import Header from "./Header"
 import Sitemap from "../../../../sitemap.json"
-import { HeaderProps } from "~/common"
+import type { HeaderProps } from "~/common"
 
 export default {
   title: "Classic/Components/Header",
   component: Header,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Classic",
+    },
+  },
 } as Meta
 
 // Template for stories

--- a/src/templates/classic/components/Hero/Hero.stories.tsx
+++ b/src/templates/classic/components/Hero/Hero.stories.tsx
@@ -5,6 +5,11 @@ export default {
   title: "Classic/Components/Hero",
   component: Hero,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Classic",
+    },
+  },
 } as Meta
 
 // Template for stories

--- a/src/templates/classic/components/Image/Image.stories.tsx
+++ b/src/templates/classic/components/Image/Image.stories.tsx
@@ -1,11 +1,16 @@
-import { Meta, StoryFn } from "@storybook/react"
+import type { Meta, StoryFn } from "@storybook/react"
 import Image from "./Image"
-import { ImageProps } from "~/common"
+import type { ImageProps } from "~/common"
 
 export default {
   title: "Classic/Components/Image",
   component: Image,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Classic",
+    },
+  },
 } as Meta
 
 // Template for stories

--- a/src/templates/classic/components/InfoCards/InfoCards.stories.tsx
+++ b/src/templates/classic/components/InfoCards/InfoCards.stories.tsx
@@ -1,6 +1,6 @@
-import { Meta, StoryFn } from "@storybook/react"
+import type { Meta, StoryFn } from "@storybook/react"
 import InfoCards from "./InfoCards"
-import { InfoCardsProps } from "~/common"
+import type { InfoCardsProps } from "~/common"
 
 export default {
   title: "Classic/Components/InfoCards",
@@ -10,6 +10,11 @@ export default {
     imageUrl: { control: "text" },
     title: { control: "text" },
     text: { control: "text" },
+  },
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Classic",
+    },
   },
 } as Meta
 

--- a/src/templates/classic/components/Infobar/Infobar.stories.tsx
+++ b/src/templates/classic/components/Infobar/Infobar.stories.tsx
@@ -1,11 +1,16 @@
-import { Meta, StoryFn } from "@storybook/react"
+import type { Meta, StoryFn } from "@storybook/react"
 import Infobar from "./Infobar"
-import { InfobarProps } from "~/common"
+import type { InfobarProps } from "~/common"
 
 export default {
   title: "Classic/Components/Infobar",
   component: Infobar,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Classic",
+    },
+  },
 } as Meta
 
 // Template for stories

--- a/src/templates/classic/components/Infopic/Infopic.stories.tsx
+++ b/src/templates/classic/components/Infopic/Infopic.stories.tsx
@@ -1,11 +1,16 @@
-import { Meta, StoryFn } from "@storybook/react"
+import type { Meta, StoryFn } from "@storybook/react"
 import InfoPic from "./Infopic"
-import { InfopicProps } from "~/common"
+import type { InfopicProps } from "~/common"
 
 export default {
   title: "Classic/Components/Infopic",
   component: InfoPic,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Classic",
+    },
+  },
 } as Meta
 
 // Template for stories

--- a/src/templates/classic/components/Masthead/Masthead.stories.tsx
+++ b/src/templates/classic/components/Masthead/Masthead.stories.tsx
@@ -1,11 +1,16 @@
 import type { StoryFn, Meta } from "@storybook/react"
 import Masthead from "./Masthead"
-import { MastheadProps } from "~/common"
+import type { MastheadProps } from "~/common"
 
 export default {
   title: "Classic/Components/Masthead",
   component: Masthead,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Classic",
+    },
+  },
 } as Meta
 
 // Template for stories

--- a/src/templates/classic/components/Search/Search.stories.tsx
+++ b/src/templates/classic/components/Search/Search.stories.tsx
@@ -1,11 +1,16 @@
-import { StoryFn, Meta } from "@storybook/react"
+import type { StoryFn, Meta } from "@storybook/react"
 import Search from "./Search"
-import { SearchProps } from "~/common"
+import type { SearchProps } from "~/common"
 
 export default {
   title: "Classic/Components/Search",
   component: Search,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Classic",
+    },
+  },
 } as Meta
 
 // Template for stories

--- a/src/templates/classic/components/SidePane/SidePane.stories.tsx
+++ b/src/templates/classic/components/SidePane/SidePane.stories.tsx
@@ -1,11 +1,17 @@
-import { Meta, StoryFn } from "@storybook/react"
+import type { Meta, StoryFn } from "@storybook/react"
 import SidePane from "./SidePane"
 import Sitemap from "../../../../sitemap.json"
-import { SidePaneProps } from "~/common"
+import type { SidePaneProps } from "~/common"
+
 export default {
   title: "Classic/Components/SidePane",
   component: SidePane,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Classic",
+    },
+  },
 } as Meta
 
 // Template for stories

--- a/src/templates/next/components/Button/Button.stories.tsx
+++ b/src/templates/next/components/Button/Button.stories.tsx
@@ -1,11 +1,16 @@
-import { Meta, StoryFn } from "@storybook/react"
+import type { Meta, StoryFn } from "@storybook/react"
 import Button from "./Button"
-import { ButtonProps } from "~/common"
+import type { ButtonProps } from "~/common"
 
 export default {
   title: "Next/Components/Button",
   component: Button,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Next",
+    },
+  },
 } as Meta
 
 // Template for stories

--- a/src/templates/next/components/Navbar/Navbar.stories.tsx
+++ b/src/templates/next/components/Navbar/Navbar.stories.tsx
@@ -1,4 +1,4 @@
-import { Story, Meta } from "@storybook/react"
+import type { Meta, StoryFn } from "@storybook/react"
 import Navbar, { IsomerNavProps, NavbarLink } from "./Navbar"
 import { Navbar as NavbarConfig } from "~/config/navbar"
 
@@ -6,10 +6,15 @@ export default {
   title: "Next/Components/Navbar",
   component: Navbar,
   argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Next",
+    },
+  },
 } as Meta
 
 // Template for stories
-const Template: Story<IsomerNavProps> = (args) => <Navbar {...args} />
+const Template: StoryFn<IsomerNavProps> = (args) => <Navbar {...args} />
 
 // Default scenario
 export const Default = Template.bind({})

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,9 +42,6 @@ export default {
           secondaryColor: "var(--color-secondary)",
         },
       },
-      fontFamily: {
-        sans: ["Lato", "ui-sans-serif", "system-ui"],
-      },
       typography: ({ theme }) => ({
         isomer: {
           css: {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We currently default to using Lato for everything, even though Isomer Next uses Inter.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Use Storybook's native support for switching themes to allow us to specify the theme to use.