### PR TITLE
feat: use separate theme presets for each template

### DIFF
--- a/src/presets/classic.js
+++ b/src/presets/classic.js
@@ -3,6 +3,21 @@ export default {
   theme: {
     extend: {
       colors: {
+        border: {
+          light: "#d6d6d6",
+        },
+        canvas: {
+          base: "#ffffff",
+          inverse: "#000000",
+          translucentGrey: "#00000080",
+        },
+        header: "#2164da",
+        headings: "#6d58bb",
+        navItems: "#323232",
+        paragraph: "#344054",
+        prose: "#484848",
+        subtitle: "#344054",
+        subtleLink: "#767676",
         site: {
           primary: {
             DEFAULT: "#6031b6",
@@ -13,6 +28,16 @@ export default {
           },
         },
       },
+      typography: ({ theme }) => ({
+        isomer: {
+          css: {
+            "--tw-prose-body": theme("colors.prose"),
+            "--tw-prose-headings": theme("colors.headings"),
+            "--tw-prose-bullets": theme("colors.prose"),
+            "--tw-prose-links": theme("colors.site.secondary"),
+          },
+        },
+      }),
     },
   },
 }

--- a/src/presets/classic.js
+++ b/src/presets/classic.js
@@ -1,0 +1,18 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  theme: {
+    extend: {
+      colors: {
+        site: {
+          primary: {
+            DEFAULT: "#6031b6",
+            hover: "#4b268e",
+          },
+          secondary: {
+            DEFAULT: "#4372d6",
+          },
+        },
+      },
+    },
+  },
+}

--- a/src/presets/next.js
+++ b/src/presets/next.js
@@ -1,0 +1,53 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  theme: {
+    extend: {
+      colors: {
+        subtitle: "#344054",
+        paragraph: "#344054",
+        dark: "#6d58bb",
+        prose: "#484848",
+        headings: "#6d58bb",
+        header: "#2164da",
+        subtleLink: "#767676",
+        navItems: "#323232",
+        border: {
+          light: "#d6d6d6",
+        },
+        canvas: {
+          base: "#ffffff",
+          inverse: "#000000",
+          translucentGrey: "#00000080",
+          dark: "#2B2313",
+        },
+        content: {
+          default: "#333333",
+          strong: "#2c2e34",
+          medium: "#5d5d5d",
+          inverse: "#ffffff",
+        },
+        interaction: {
+          hover: "#f9f9f9",
+          linkDefault: "#4372d6",
+          linkHover: "#3a79ff",
+        },
+        stroke: {
+          default: "#d0d5dd",
+        },
+      },
+      screens: {
+        xs: "576px",
+      },
+      typography: ({ theme }) => ({
+        isomer: {
+          css: {
+            "--tw-prose-body": theme("colors.prose"),
+            "--tw-prose-headings": theme("colors.headings"),
+            "--tw-prose-bullets": theme("colors.prose"),
+            "--tw-prose-links": theme("colors.site.secondary"),
+          },
+        },
+      }),
+    },
+  },
+}

--- a/src/presets/next.js
+++ b/src/presets/next.js
@@ -48,6 +48,16 @@ export default {
             active: "#333333",
           },
         },
+        site: {
+          primary: {
+            DEFAULT: "#f78f1e",
+            100: "#fef4e8",
+            200: "#ffeec2",
+          },
+          secondary: {
+            DEFAULT: "#877664",
+          },
+        },
       },
       screens: {
         xs: "576px",

--- a/src/presets/next.js
+++ b/src/presets/next.js
@@ -3,51 +3,55 @@ export default {
   theme: {
     extend: {
       colors: {
-        subtitle: "#344054",
-        paragraph: "#344054",
-        dark: "#6d58bb",
-        prose: "#484848",
-        headings: "#6d58bb",
-        header: "#2164da",
-        subtleLink: "#767676",
-        navItems: "#323232",
-        border: {
-          light: "#d6d6d6",
-        },
         canvas: {
-          base: "#ffffff",
-          inverse: "#000000",
-          translucentGrey: "#00000080",
           dark: "#2B2313",
         },
         content: {
-          default: "#333333",
-          strong: "#2c2e34",
+          DEFAULT: "#333333",
           medium: "#5d5d5d",
+          strong: "#2c2e34",
           inverse: "#ffffff",
         },
-        interaction: {
-          hover: "#f9f9f9",
-          linkDefault: "#4372d6",
-          linkHover: "#3a79ff",
+        hyperlink: {
+          DEFAULT: "#1361f0",
+          inverse: "#ffffff",
+          hover: {
+            DEFAULT: "#0d4fca",
+            inverse: "#ededed",
+          },
+          visited: {
+            DEFAULT: "#530085",
+            inverse: "#ffffff",
+          },
         },
-        stroke: {
-          default: "#d0d5dd",
+        focus: {
+          outline: "#0d4fca",
+        },
+        divider: {
+          medium: "#d0d0d0",
+        },
+        utility: {
+          info: {
+            DEFAULT: "#87bdff",
+            subtle: "#e0eeff",
+          },
+        },
+        interaction: {
+          main: {
+            DEFAULT: "#333333",
+            hover: "#f78d1b",
+            active: "#f78d1b",
+          },
+          link: {
+            DEFAULT: "#333333",
+            hover: "#333333",
+            active: "#333333",
+          },
         },
       },
       screens: {
         xs: "576px",
       },
-      typography: ({ theme }) => ({
-        isomer: {
-          css: {
-            "--tw-prose-body": theme("colors.prose"),
-            "--tw-prose-headings": theme("colors.headings"),
-            "--tw-prose-bullets": theme("colors.prose"),
-            "--tw-prose-links": theme("colors.site.secondary"),
-          },
-        },
-      }),
     },
   },
 }

--- a/src/templates/classic/components/Button/Button.tsx
+++ b/src/templates/classic/components/Button/Button.tsx
@@ -2,7 +2,11 @@ import { ButtonProps } from "~/common"
 
 // Classic Button does not use much from ButtonProps, e.g bg colour is always site's secondary colour
 const Button = ({ label, href }: ButtonProps) => {
-  const Label = () => <span className="uppercase text-white text-center tracking-wider">{label}</span>
+  const Label = () => (
+    <span className="uppercase text-white text-center tracking-wider">
+      {label}
+    </span>
+  )
 
   return (
     <a
@@ -10,7 +14,7 @@ const Button = ({ label, href }: ButtonProps) => {
       target={href.startsWith("http") ? "_blank" : undefined}
       rel={href.startsWith("http") ? "noopener noreferrer nofollow" : undefined}
       type="button"
-      className="px-6 py-4 bg-secondary"
+      className="px-6 py-4 bg-site-secondary"
     >
       <Label />
     </a>

--- a/src/templates/classic/components/Hero/Hero.tsx
+++ b/src/templates/classic/components/Hero/Hero.tsx
@@ -125,7 +125,7 @@ const HeroCenter = ({
                       : ""
                   }
                   target={buttonUrl.startsWith("http") ? "_blank" : ""}
-                  className={`${BP_BUTTON_CLASSES} bg-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
+                  className={`${BP_BUTTON_CLASSES} bg-site-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
                 >
                   {buttonLabel}
                 </a>
@@ -144,7 +144,10 @@ const HeroKeyHighlights = ({ keyHighlights }: HeroKeyHighlightProps) => {
   }
 
   return (
-    <section id="key-highlights" className="p-0 lg:px-6 bg-primary text-white">
+    <section
+      id="key-highlights"
+      className="p-0 lg:px-6 bg-site-primary text-white"
+    >
       <div className="mx-auto my-0 relative lg:max-w-[60rem] xl:max-w-[76rem] 2xl:max-w-[84rem]">
         <div className={`m-0 text-center justify-center flex-none md:flex`}>
           {keyHighlights
@@ -155,7 +158,7 @@ const HeroKeyHighlights = ({ keyHighlights }: HeroKeyHighlightProps) => {
                 title: highlightTitle,
                 description: highlightDescription,
               }) => (
-                <div className="transition-colors hover:bg-primaryHover cursor-pointer grow basis-0 border-solid border-l first:border-l-0 border-l-subtitle">
+                <div className="transition-colors hover:bg-site-primary-hover cursor-pointer grow basis-0 border-solid border-l first:border-l-0 border-l-subtitle">
                   <a
                     href={highlightUrl}
                     rel={

--- a/src/templates/classic/components/Hero/HeroDropdown.tsx
+++ b/src/templates/classic/components/Hero/HeroDropdown.tsx
@@ -56,7 +56,7 @@ export const HeroDropdown = ({ title, options }: HeroDropdownProps) => {
               optionUrl &&
               optionTitle && (
                 <a
-                  className="block relative text-prose hover:text-secondary text-xl px-6 py-3"
+                  className="block relative text-prose hover:text-site-secondary text-xl px-6 py-3"
                   href={optionUrl}
                   rel={
                     optionUrl.startsWith("http")

--- a/src/templates/classic/components/Hero/HeroInfobox.tsx
+++ b/src/templates/classic/components/Hero/HeroInfobox.tsx
@@ -113,7 +113,7 @@ export const HeroInfoboxDesktop = ({
                     : ""
                 }
                 target={buttonUrl.startsWith("http") ? "_blank" : ""}
-                className={`${BP_BUTTON_CLASSES} bg-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
+                className={`${BP_BUTTON_CLASSES} bg-site-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
               >
                 {buttonLabel}
               </a>
@@ -168,7 +168,7 @@ export const HeroInfoboxTablet = ({
                       : ""
                   }
                   target={buttonUrl.startsWith("http") ? "_blank" : ""}
-                  className={`${BP_BUTTON_CLASSES} bg-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
+                  className={`${BP_BUTTON_CLASSES} bg-site-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
                 >
                   {buttonLabel}
                 </a>
@@ -213,7 +213,7 @@ export const HeroInfoboxMobile = ({
                     : ""
                 }
                 target={buttonUrl.startsWith("http") ? "_blank" : ""}
-                className={`${BP_BUTTON_CLASSES} bg-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
+                className={`${BP_BUTTON_CLASSES} bg-site-secondary text-content-inverse border-transparent uppercase px-6 py-[7px] text-base tracking-wider font-semibold h-[2.4rem]`}
               >
                 {buttonLabel}
               </a>

--- a/src/templates/classic/components/InfoCols/InfoCols.tsx
+++ b/src/templates/classic/components/InfoCols/InfoCols.tsx
@@ -10,7 +10,7 @@ const InfoColsHeader = ({
     {subtitle && (
       <p className="text-subtitle uppercase tracking-widest">{subtitle}</p>
     )}
-    <h1 className="text-secondary text-5xl font-semibold leading-tight">
+    <h1 className="text-site-secondary text-5xl font-semibold leading-tight">
       {title}
     </h1>
   </div>
@@ -54,7 +54,7 @@ const InfoColsFooter = ({
     buttonUrl && (
       <div className="text-lg font-semibold uppercase">
         <a
-          className="flex gap-2 text-secondary font-semibold text-center underline uppercase tracking-wide"
+          className="flex gap-2 text-site-secondary font-semibold text-center underline uppercase tracking-wide"
           href={buttonUrl}
           target={buttonUrl.startsWith("http") ? "_blank" : undefined}
           rel={
@@ -65,7 +65,7 @@ const InfoColsFooter = ({
         >
           {buttonLabel}
           <div className="my-auto">
-            <ArrowRightIcon className="text-secondary size-5" />
+            <ArrowRightIcon className="text-site-secondary size-5" />
           </div>
         </a>
       </div>

--- a/src/templates/classic/components/Infobar/Infobar.tsx
+++ b/src/templates/classic/components/Infobar/Infobar.tsx
@@ -20,7 +20,7 @@ const Infobar = ({
                 {subtitle}
               </p>
             )}
-            <h1 className="text-secondary text-5xl">
+            <h1 className="text-site-secondary text-5xl">
               <b className="font-semibold">{title}</b>
             </h1>
             {description && (
@@ -30,7 +30,7 @@ const Infobar = ({
           {buttonLabel && buttonUrl && (
             <div className="p-3 text-lg font-semibold uppercase">
               <a
-                className="flex gap-2 text-secondary font-semibold text-center underline uppercase tracking-wide"
+                className="flex gap-2 text-site-secondary font-semibold text-center underline uppercase tracking-wide"
                 href={buttonUrl}
                 target={buttonUrl.startsWith("http") ? "_blank" : undefined}
                 rel={
@@ -41,7 +41,7 @@ const Infobar = ({
               >
                 {buttonLabel}
                 <div className="my-auto">
-                  <ArrowRightIcon className="text-secondary size-5" />
+                  <ArrowRightIcon className="text-site-secondary size-5" />
                 </div>
               </a>
             </div>

--- a/src/templates/classic/components/Infopic/Infopic.tsx
+++ b/src/templates/classic/components/Infopic/Infopic.tsx
@@ -30,12 +30,12 @@ const TextComponent = ({
       {subtitle && (
         <p className="text-subtitle uppercase tracking-widest">{subtitle}</p>
       )}
-      <h1 className="text-secondary text-5xl font-semibold">{title}</h1>
+      <h1 className="text-site-secondary text-5xl font-semibold">{title}</h1>
       {description && <p className="text-paragraph text-xl">{description}</p>}
       {buttonLabel && buttonUrl && (
         <div className="text-lg font-semibold uppercase tracking-wid">
           <a
-            className="flex gap-2 text-secondary font-semibold underline uppercase"
+            className="flex gap-2 text-site-secondary font-semibold underline uppercase"
             href={buttonUrl}
             target={buttonUrl.startsWith("http") ? "_blank" : undefined}
             rel={
@@ -47,7 +47,7 @@ const TextComponent = ({
             {buttonLabel}
 
             <div className="my-auto">
-              <ArrowRightIcon className="text-secondary size-5" />
+              <ArrowRightIcon className="text-site-secondary size-5" />
             </div>
           </a>
         </div>

--- a/src/templates/classic/components/Search/Search.tsx
+++ b/src/templates/classic/components/Search/Search.tsx
@@ -136,7 +136,10 @@ const Search: React.FC<SearchProps> = ({ index }) => {
         <ul>
           {currentResults.map((result) => (
             <li key={String(result.id)} className="px-4 py-4 sm:px-6">
-              <a className="text-secondary text-xl underline" href={result.url}>
+              <a
+                className="text-site-secondary text-xl underline"
+                href={result.url}
+              >
                 {result.title}
               </a>
               <p className="text-md text-subtleLink">{result.url}</p>

--- a/src/templates/next/components/Hero/Hero.tsx
+++ b/src/templates/next/components/Hero/Hero.tsx
@@ -164,7 +164,7 @@ const HeroFloating = ({
   secondaryButtonUrl,
   backgroundUrl,
 }: Omit<HeroFloatingProps, "variant">) => {
-  const bgColor = backgroundColor === "black" ? "bg-canvas-black" : "bg-white"
+  const bgColor = backgroundColor === "black" ? "bg-canvas-dark" : "bg-white"
   const textColor = backgroundColor === "black" ? "text-white" : "text-black"
 
   return (

--- a/src/templates/next/components/Hero/Hero.tsx
+++ b/src/templates/next/components/Hero/Hero.tsx
@@ -227,7 +227,7 @@ const HeroCopyLed = ({
 }: Omit<HeroCopyLedProps, "variant">) => {
   return (
     <section className="h-[32rem]">
-      <div className="bg-[#ffeec2] w-full flex flex-row justify-center">
+      <div className="bg-site-primary-200 w-full flex flex-row justify-center">
         <div className="w-4/5 lg:w-3/4 py-16 flex flex-col items-center text-center md:items-start md:text-start gap-6">
           <h1 className="text-6xl font-normal">{title}</h1>
           {subtitle && <p className="text-2xl leading-9">{subtitle}</p>}
@@ -273,7 +273,7 @@ const HeroFloatingImage = ({
   return (
     <>
       <section className="hidden md:block h-[32rem]">
-        <div className="bg-[#ffeec2] w-full flex flex-row justify-center">
+        <div className="bg-site-primary-200 w-full flex flex-row justify-center">
           <div className="w-4/5 lg:w-3/4 py-16 flex flex-row gap-24">
             <div className="flex flex-col w-1/2 gap-6">
               <h1 className="text-6xl font-medium">{title}</h1>

--- a/src/templates/next/components/InfoCols/InfoCols.tsx
+++ b/src/templates/next/components/InfoCols/InfoCols.tsx
@@ -19,7 +19,7 @@ const InfoBoxIcon = ({ icon }: { icon?: SupportedIconName }) => {
   const Icon = SUPPORTED_ICONS_MAP[icon]
   return (
     <div>
-      <Icon className="w-10 h-auto text-secondary" />
+      <Icon className="w-10 h-auto text-site-secondary" />
     </div>
   )
 }

--- a/src/templates/next/components/InfoCols/InfoCols.tsx
+++ b/src/templates/next/components/InfoCols/InfoCols.tsx
@@ -19,7 +19,7 @@ const InfoBoxIcon = ({ icon }: { icon?: SupportedIconName }) => {
   const Icon = SUPPORTED_ICONS_MAP[icon]
   return (
     <div>
-      <Icon className="w-10 h-auto text-site-secondary" />
+      <Icon className="w-10 h-auto text-site-primary" />
     </div>
   )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,61 +1,25 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  presets: [
+    require("./src/presets/next.js"),
+    // Note: This is here temporarily until we can figure out how to load the
+    // presets dynamically depending on the template being used.
+    require("./src/presets/classic.js"),
+  ],
   theme: {
     extend: {
       colors: {
-        primary: "#6031b6",
-        primaryHover: "#4b268e",
-        secondary: "#4372d6",
-        subtitle: "#344054",
-        paragraph: "#344054",
-        dark: "#6d58bb",
-        prose: "#484848",
-        headings: "#6d58bb",
-        header: "#2164da",
-        subtleLink: "#767676",
-        navItems: "#323232",
-        border: {
-          light: "#d6d6d6",
-        },
-        canvas: {
-          base: "#ffffff",
-          inverse: "#000000",
-          translucentGrey: "#00000080",
-          dark: "#2B2313",
-        },
-        content: {
-          default: "#333333",
-          strong: "#2c2e34",
-          medium: "#5d5d5d",
-          inverse: "#ffffff",
-        },
-        interaction: {
-          hover: "#f9f9f9",
-          linkDefault: "#4372d6",
-          linkHover: "#3a79ff",
-        },
-        stroke: {
-          default: "#d0d5dd",
-        },
-        utility: {
-          themeColor: "var(--color-primary)",
-          secondaryColor: "var(--color-secondary)",
-        },
-      },
-      screens: {
-        xs: "576px",
-      },
-      typography: ({ theme }) => ({
-        isomer: {
-          css: {
-            "--tw-prose-body": theme("colors.prose"),
-            "--tw-prose-headings": theme("colors.headings"),
-            "--tw-prose-bullets": theme("colors.prose"),
-            "--tw-prose-links": theme("colors.secondary"),
+        // Site-specific colors, will be overwritten by individual sites
+        site: {
+          primary: {
+            DEFAULT: "#f78f1e",
+          },
+          secondary: {
+            DEFAULT: "#877664",
           },
         },
-      }),
+      },
     },
   },
   plugins: [require("@tailwindcss/forms"), require("@tailwindcss/typography")],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,8 @@ export default {
         site: {
           primary: {
             DEFAULT: "#f78f1e",
+            100: "#fef4e8",
+            200: "#ffeec2",
           },
           secondary: {
             DEFAULT: "#877664",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Our theme presets is a little messy right now.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Separate the theme presets for each template. This also allows us to publish the presets as a separate NPM package in the future, and downstream sites can just import the package, layer the site-specific theme colours on top, and build the final site.