### PR TITLE
feat: add callout component

### DIFF
--- a/src/common/Callout.ts
+++ b/src/common/Callout.ts
@@ -1,0 +1,5 @@
+export interface CalloutProps {
+  content: string
+}
+
+export default CalloutProps

--- a/src/common/Callout.ts
+++ b/src/common/Callout.ts
@@ -1,5 +1,14 @@
+export const CalloutVariants = [
+  "info",
+  "success",
+  "warning",
+  "critical",
+] as const
+export type CalloutVariant = (typeof CalloutVariants)[number]
+
 export interface CalloutProps {
   content: string
+  variant: CalloutVariant
 }
 
 export default CalloutProps

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,4 +1,5 @@
 export { default as ButtonProps } from "./Button"
+export { default as CalloutProps } from "./Callout"
 export { default as CardsProps } from "./Cards"
 export { default as ContentProps } from "./Content"
 export { default as FooterProps } from "./Footer"

--- a/src/templates/next/components/Callout/Callout.stories.tsx
+++ b/src/templates/next/components/Callout/Callout.stories.tsx
@@ -1,0 +1,23 @@
+import { Meta, StoryFn } from "@storybook/react"
+import Callout from "./Callout"
+import { CalloutProps } from "~/common"
+
+export default {
+  title: "Next/Components/Callout",
+  component: Callout,
+  argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Next",
+    },
+  },
+} as Meta
+
+// Template for stories
+const Template: StoryFn<CalloutProps> = (args) => <Callout {...args} />
+
+// Default scenario
+export const Default = Template.bind({})
+Default.args = {
+  content: `As of December 1, 2024, the scheme is being reviewed for new criteria in 2025. To view the new criteria please refer to <a href="/faq">New Idea Scheme Proposal</a> while it is being updated.`,
+}

--- a/src/templates/next/components/Callout/Callout.tsx
+++ b/src/templates/next/components/Callout/Callout.tsx
@@ -1,10 +1,10 @@
 import { CalloutProps } from "~/common"
 import Paragraph from "../Paragraph"
 
-const Callout = ({ content }: CalloutProps) => {
+const Callout = ({ content, variant }: CalloutProps) => {
   return (
     <>
-      <div className="bg-[#E0EEFF] p-6 text-content-default text-lg leading-7 border border-[#87BDFF] rounded ">
+      <div className="bg-utility-info-subtle p-6 text-content-default text-lg leading-7 border border-utility-info rounded">
         <Paragraph content={content} />
       </div>
     </>

--- a/src/templates/next/components/Callout/Callout.tsx
+++ b/src/templates/next/components/Callout/Callout.tsx
@@ -1,0 +1,14 @@
+import { CalloutProps } from "~/common"
+import Paragraph from "../Paragraph"
+
+const Callout = ({ content }: CalloutProps) => {
+  return (
+    <>
+      <div className="bg-[#E0EEFF] p-6 text-content-default text-lg leading-7 border border-[#87BDFF] rounded ">
+        <Paragraph content={content} />
+      </div>
+    </>
+  )
+}
+
+export default Callout

--- a/src/templates/next/components/Callout/index.ts
+++ b/src/templates/next/components/Callout/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Callout"

--- a/src/templates/next/components/Paragraph/Paragraph.tsx
+++ b/src/templates/next/components/Paragraph/Paragraph.tsx
@@ -5,7 +5,7 @@ const Paragraph = ({ content }: ParagraphProps) => {
   const sanitizedContent = getSanitizedInlineContent(content)
   return (
     <p
-      className="[&_a]:underline [&_a]:text-blue-500 hover:[&_a]:text-blue-700"
+      className="[&_a]:underline [&_a]:underline-offset-2 [&_a]:text-blue-500 hover:[&_a]:text-blue-700"
       dangerouslySetInnerHTML={{ __html: sanitizedContent }}
     />
   )

--- a/src/templates/next/components/index.ts
+++ b/src/templates/next/components/index.ts
@@ -1,4 +1,5 @@
 export { default as Button } from "./Button"
+export { default as Callout } from "./Callout"
 export { default as Infobar } from "./Infobar"
 export { default as InfoCols } from "./InfoCols"
 export { default as Infopic } from "./Infopic"


### PR DESCRIPTION
uses Paragraph component to get mark support out of the box
https://linear.app/ogp/issue/ISOM-786/create-callout-component-in-isomer-next

only adding Info variant for now as other variants are not designed yet
https://www.figma.com/file/8TEzSSDbx97gctRJ7nKdqG/Website-Template-Gen-2?type=design&node-id=1064-7687&mode=design&t=B0tzSBrd08CX5BvG-0

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [insert issue #]

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
