### PR TITLE
fix: supply lastUpdated instead of using current time in Skeleton

### DIFF
--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -76,6 +76,7 @@ interface IsomerSiteProps {
   isGovernment?: boolean
   environment?: string
   favicon?: MetaHeadProps["favicon"]
+  lastUpdated: string
   navBarItems: NavbarProps["items"]
   footerItems: SiteConfigFooterProps
 }

--- a/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -33,6 +33,7 @@ Default.args = {
       termsOfUseLink: "https://www.isomer.gov.sg/terms",
       siteNavItems: [],
     },
+    lastUpdated: "1 Jan 2021",
   },
   page: {
     title: "Publications and other press releases",

--- a/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/src/templates/next/layouts/Content/Content.stories.tsx
@@ -31,6 +31,7 @@ Default.args = {
       termsOfUseLink: "https://www.isomer.gov.sg/terms",
       siteNavItems: [],
     },
+    lastUpdated: "1 Jan 2021",
   },
   page: {
     title: "Content page",

--- a/src/templates/next/layouts/Homepage/Homepage.stories.tsx
+++ b/src/templates/next/layouts/Homepage/Homepage.stories.tsx
@@ -31,6 +31,7 @@ Default.args = {
       termsOfUseLink: "https://www.isomer.gov.sg/terms",
       siteNavItems: [],
     },
+    lastUpdated: "1 Jan 2021",
   },
   page: {
     title: "Home page",

--- a/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -11,13 +11,6 @@ export const Skeleton = ({
   Pick<IsomerPageSchema, "site" | "page" | "HeadComponent" | "LinkComponent">
 >) => {
   const isStaging = site.environment === "staging"
-  const timeNow = new Date()
-  const lastUpdated =
-    timeNow.getDate().toString().padStart(2, "0") +
-    " " +
-    timeNow.toLocaleString("default", { month: "short" }) +
-    " " +
-    timeNow.getFullYear()
 
   return (
     <>
@@ -59,7 +52,7 @@ export const Skeleton = ({
           isGovernment: site.isGovernment,
           siteName: site.siteName,
           agencyName: site.agencyName || site.siteName,
-          lastUpdated,
+          lastUpdated: site.lastUpdated,
           ...site.footerItems,
         },
         LinkComponent,


### PR DESCRIPTION
move lastUpdated to props instead of letting `Skeleton` always use current time
(this was also causing chromatic to keep reporting diffs on the layout stories)
moved that logic to the template instead : https://github.com/isomerpages/isomer-next-base-template/pull/1