### PR TITLE
feat: introduce SearchSG embedded results page

### DIFF
--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -97,6 +97,7 @@ export interface CollectionPageProps extends BasePageProps {
   items: CollectionCardProps[]
   subtitle: string
 }
+export interface SearchSGPageProps extends BasePageProps {}
 
 export interface BasePageSchema {
   version: string
@@ -121,7 +122,13 @@ export interface CollectionPageSchema extends BasePageSchema {
   page: CollectionPageProps
 }
 
+export interface SearchSGPageSchema extends BasePageSchema {
+  layout: "searchsg"
+  page: SearchSGPageProps
+}
+
 export type IsomerPageSchema =
   | HomePageSchema
   | ContentPageSchema
   | CollectionPageSchema
+  | SearchSGPageSchema

--- a/src/templates/next/layouts/Collection/Collection.tsx
+++ b/src/templates/next/layouts/Collection/Collection.tsx
@@ -184,6 +184,8 @@ const CollectionLayout = ({
   site,
   page,
   LinkComponent,
+  HeadComponent,
+  ScriptComponent,
 }: CollectionPageSchema) => {
   const ITEMS_PER_PAGE = 6
   const { defaultSortBy, defaultSortDirection, items, subtitle, title } = page
@@ -207,7 +209,13 @@ const CollectionLayout = ({
   )
 
   return (
-    <Skeleton site={site} page={page} LinkComponent={LinkComponent}>
+    <Skeleton
+      site={site}
+      page={page}
+      LinkComponent={LinkComponent}
+      HeadComponent={HeadComponent}
+      ScriptComponent={ScriptComponent}
+    >
       <div className="max-w-[1140px] flex flex-col gap-16 mx-auto my-20 items-center">
         <div className="flex flex-col gap-12">
           <h1

--- a/src/templates/next/layouts/Content/Content.tsx
+++ b/src/templates/next/layouts/Content/Content.tsx
@@ -106,6 +106,8 @@ const ContentLayout = ({
   page,
   content,
   LinkComponent,
+  HeadComponent,
+  ScriptComponent,
 }: ContentPageSchema) => {
   const sideRail = getSiderailFromSiteMap(
     site.siteMap,
@@ -117,7 +119,13 @@ const ContentLayout = ({
     page.permalink.split("/").slice(1),
   )
   return (
-    <Skeleton site={site} page={page} LinkComponent={LinkComponent}>
+    <Skeleton
+      site={site}
+      page={page}
+      LinkComponent={LinkComponent}
+      HeadComponent={HeadComponent}
+      ScriptComponent={ScriptComponent}
+    >
       {sideRail && (
         <div className="lg:hidden">
           <Siderail {...sideRail} LinkComponent={LinkComponent} />

--- a/src/templates/next/layouts/Homepage/Homepage.tsx
+++ b/src/templates/next/layouts/Homepage/Homepage.tsx
@@ -7,9 +7,17 @@ const HomepageLayout = ({
   page,
   content,
   LinkComponent,
+  HeadComponent,
+  ScriptComponent,
 }: HomePageSchema) => {
   return (
-    <Skeleton site={site} page={page} LinkComponent={LinkComponent}>
+    <Skeleton
+      site={site}
+      page={page}
+      LinkComponent={LinkComponent}
+      HeadComponent={HeadComponent}
+      ScriptComponent={ScriptComponent}
+    >
       <div
         // ComponentContent = "component-content" (customCssClass.ts) is imported by all Homepage components,
         // but cannot be used here as tailwind does not support dynamic class names

--- a/src/templates/next/layouts/SearchSG/SearchSG.stories.tsx
+++ b/src/templates/next/layouts/SearchSG/SearchSG.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryFn } from "@storybook/react"
+import { SearchSGPageSchema } from "~/engine"
+import SearchSGLayout from "./SearchSG"
+import { useEffect } from "react"
+
+export default {
+  title: "Next/Layouts/SearchSG",
+  component: SearchSGLayout,
+  argTypes: {},
+  parameters: {
+    themes: {
+      themeOverride: "Isomer Next",
+    },
+  },
+} as Meta
+const TEST_CLIENT_ID = "7946e346-993e-41c7-bd81-26a3999dc3f4"
+
+// Template for stories
+const Template: StoryFn<SearchSGPageSchema> = (args) => {
+  // Note: This is needed because the script tag is not rendered in the storybook
+  useEffect(() => {
+    const scriptTag = document.createElement("script")
+    scriptTag.src = `https://api.search.gov.sg/v1/searchconfig.js?clientId=${TEST_CLIENT_ID}&page=result`
+    scriptTag.setAttribute("defer", "")
+    document.body.appendChild(scriptTag)
+  }, [])
+
+  return <SearchSGLayout {...args} />
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  layout: "searchsg",
+  site: {
+    siteName: "Isomer Next",
+    siteMap: [],
+    theme: "isomer-next",
+    isGovernment: true,
+    logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
+    navBarItems: [],
+    footerItems: {
+      privacyStatementLink: "https://www.isomer.gov.sg/privacy",
+      termsOfUseLink: "https://www.isomer.gov.sg/terms",
+      siteNavItems: [],
+    },
+    lastUpdated: "1 Jan 2021",
+    search: {
+      type: "searchSG",
+      clientId: TEST_CLIENT_ID,
+    },
+  },
+  page: {
+    title: "Search",
+    description: "Search results",
+  },
+}

--- a/src/templates/next/layouts/SearchSG/SearchSG.tsx
+++ b/src/templates/next/layouts/SearchSG/SearchSG.tsx
@@ -4,6 +4,8 @@ import { Skeleton } from "../Skeleton"
 const SearchSGLayout = ({
   site,
   page,
+  LinkComponent = "a",
+  HeadComponent = "head",
   ScriptComponent = "script",
 }: SearchSGPageSchema) => {
   const clientId =
@@ -11,7 +13,13 @@ const SearchSGLayout = ({
     ""
 
   return (
-    <Skeleton site={site} page={page}>
+    <Skeleton
+      site={site}
+      page={page}
+      LinkComponent={LinkComponent}
+      HeadComponent={HeadComponent}
+      ScriptComponent={ScriptComponent}
+    >
       <ScriptComponent
         id="searchsg-config"
         src={`https://api.search.gov.sg/v1/searchconfig.js?clientId=${clientId}&page=result`}

--- a/src/templates/next/layouts/SearchSG/SearchSG.tsx
+++ b/src/templates/next/layouts/SearchSG/SearchSG.tsx
@@ -1,0 +1,25 @@
+import { SearchSGPageSchema } from "~/engine"
+import { Skeleton } from "../Skeleton"
+
+const SearchSGLayout = ({
+  site,
+  page,
+  ScriptComponent = "script",
+}: SearchSGPageSchema) => {
+  const clientId =
+    (site.search && site.search.type === "searchSG" && site.search.clientId) ||
+    ""
+
+  return (
+    <Skeleton site={site} page={page}>
+      <ScriptComponent
+        id="searchsg-config"
+        src={`https://api.search.gov.sg/v1/searchconfig.js?clientId=${clientId}&page=result`}
+        defer
+      />
+      <div id="searchsg-result-container" />
+    </Skeleton>
+  )
+}
+
+export default SearchSGLayout

--- a/src/templates/next/layouts/SearchSG/index.ts
+++ b/src/templates/next/layouts/SearchSG/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SearchSG"

--- a/src/templates/next/layouts/index.ts
+++ b/src/templates/next/layouts/index.ts
@@ -1,3 +1,5 @@
 export { renderLayout, renderComponent } from "./render"
 export { default as HomepageLayout } from "./Homepage"
 export { default as ContentLayout } from "./Content"
+export { default as CollectionLayout } from "./Collection"
+export { default as SearchSGLayout } from "./SearchSG"


### PR DESCRIPTION
Refer to the [onboarding guide](https://docs.developer.tech.gov.sg/docs/searchsg-onboarding-guide/customisation-embed?id=step-1-load-the-searchconfigjs-script-for-result-page).

Not doing the search results page yet for local search as that is more complicated + we are prioritising SearchSG integration.