### PR TITLE
Fix/autogen content layout accessories

### DIFF
--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -59,7 +59,7 @@ export type IsomerComponent = IsomerComponentProps & {
   indexable?: string[]
 }
 
-interface IsomerSitemap {
+export interface IsomerSitemap {
   title: string
   permalink: string
   children?: IsomerSitemap[]

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -68,7 +68,7 @@ interface IsomerSitemap {
 interface IsomerSiteProps {
   siteName: string
   agencyName?: string
-  siteMap: IsomerSitemap[]
+  siteMap: IsomerSitemap
   theme: "isomer-classic" | "isomer-next"
   logoUrl: string
   isGovernment?: boolean
@@ -80,6 +80,7 @@ interface IsomerSiteProps {
 }
 
 interface BasePageProps {
+  permalink: string
   title: string
   language?: "en"
   description?: string
@@ -88,8 +89,6 @@ interface BasePageProps {
 export interface HomePageProps extends BasePageProps {}
 export interface ContentPageProps extends BasePageProps {
   contentPageHeader: ContentPageHeaderProps
-  sideRail?: SiderailProps // unlinked pages will not have a siderail
-  tableOfContents: TableOfContentsProps
 }
 export interface CollectionPageProps extends BasePageProps {
   defaultSortBy: SortKey

--- a/src/templates/next/components/shared/Siderail/Siderail.tsx
+++ b/src/templates/next/components/shared/Siderail/Siderail.tsx
@@ -138,7 +138,7 @@ const SiderailDesktop = ({
   )
 }
 
-export const Siderail = (props: Omit<SiderailProps, "type">) => {
+export const Siderail = (props: SiderailProps) => {
   return (
     <>
       <SiderailMobile {...props} />

--- a/src/templates/next/layouts/Collection/Collection.tsx
+++ b/src/templates/next/layouts/Collection/Collection.tsx
@@ -207,7 +207,7 @@ const CollectionLayout = ({
   )
 
   return (
-    <Skeleton site={site} page={page}>
+    <Skeleton site={site} page={page} LinkComponent={LinkComponent}>
       <div className="max-w-[1140px] flex flex-col gap-16 mx-auto my-20 items-center">
         <div className="flex flex-col gap-12">
           <h1

--- a/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/src/templates/next/layouts/Content/Content.stories.tsx
@@ -43,8 +43,21 @@ Default.args = {
                 },
               ],
             },
-            { title: "Sibling", permalink: "/sibling" },
+            {
+              title: "Sibling",
+              permalink: "/parent/sibling",
+              children: [
+                {
+                  title: "Child that should not appear",
+                  permalink: "/parent/sibling/child-page-2",
+                },
+              ],
+            },
           ],
+        },
+        {
+          title: "Aunt/Uncle that should not appear",
+          permalink: "/aunt-uncle",
         },
       ],
     },

--- a/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/src/templates/next/layouts/Content/Content.stories.tsx
@@ -21,7 +21,33 @@ Default.args = {
   layout: "content",
   site: {
     siteName: "Isomer Next",
-    siteMap: [],
+    siteMap: {
+      title: "Isomer Next",
+      permalink: "/",
+      children: [
+        {
+          title: "Parent page",
+          permalink: "/parent",
+          children: [
+            {
+              title: "Irrationality",
+              permalink: "/parent/rationality",
+              children: [
+                {
+                  title: "For Individuals",
+                  permalink: "/parent/rationality/child-page-2",
+                },
+                {
+                  title: "Steven Pinker's Rationality",
+                  permalink: "/parent/rationality/child-page-2",
+                },
+              ],
+            },
+            { title: "Sibling", permalink: "/sibling" },
+          ],
+        },
+      ],
+    },
     theme: "isomer-next",
     isGovernment: true,
     logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
@@ -34,6 +60,7 @@ Default.args = {
     lastUpdated: "1 Jan 2021",
   },
   page: {
+    permalink: "/parent/rationality",
     title: "Content page",
     description: "A Next.js starter for Isomer",
     contentPageHeader: {
@@ -58,41 +85,6 @@ Default.args = {
       },
       buttonLabel: "Submit a proposal",
       buttonUrl: "/submit-proposal",
-    },
-    sideRail: {
-      parentTitle: "Parent page",
-      parentUrl: "/parent",
-      pages: [
-        {
-          title: "Sibling 1",
-          url: "/link1",
-        },
-        {
-          title: "Steven Pinker's Rationality",
-          url: "/link2",
-          isCurrent: true,
-        },
-        {
-          title: "Sibling 2",
-          url: "/link3",
-        },
-      ],
-    },
-    tableOfContents: {
-      items: [
-        {
-          content: "What does the Irrationality Principle support?",
-          anchorLink: "#section1",
-        },
-        {
-          content: "Checklist for sheer irrationality",
-          anchorLink: "#section2",
-        },
-        {
-          content: "Section 3",
-          anchorLink: "#section3",
-        },
-      ],
     },
   },
   content: [

--- a/src/templates/next/layouts/Content/Content.tsx
+++ b/src/templates/next/layouts/Content/Content.tsx
@@ -5,29 +5,109 @@ import TableOfContents from "../../components/shared/TableOfContents"
 import { Skeleton } from "../Skeleton"
 import { renderComponent } from "../render"
 
+const getBreadcrumbFromSiteMap = (sitemap: any, permalink: string[]) => {
+  const breadcrumb = []
+  let node = sitemap
+  let currentPath = ""
+  for (const pathSegment of permalink) {
+    currentPath += "/" + pathSegment
+    node = node.children.find((node: any) => node.permalink === currentPath)
+    breadcrumb.push({
+      title: node.title,
+      url: node.permalink,
+    })
+  }
+  return { links: breadcrumb }
+}
+
+const getSiderailFromSiteMap = (sitemap: any, permalink: string[]) => {
+  let node = sitemap
+  let currentPath = ""
+
+  let i = 0
+  while (i < permalink.length - 1) {
+    currentPath += "/" + permalink[i]
+    node = node.children.find((node: any) => node.permalink === currentPath)
+    i++
+  }
+  const parentTitle = node.title
+  const parentUrl = node.permalink
+
+  const pages = []
+  // get all siblings of page
+  const pagePath = "/" + permalink.join("/")
+  for (const sibling of node.children) {
+    if (sibling.permalink === pagePath) {
+      pages.push({
+        title: sibling.title,
+        url: sibling.permalink,
+        isCurrent: true,
+        childPages:
+          sibling.children?.map((child: any) => ({
+            url: child.permalink,
+            title: child.title,
+          })) ?? null,
+      })
+    } else {
+      pages.push({
+        title: sibling.title,
+        url: sibling.permalink,
+      })
+    }
+  }
+  return {
+    parentTitle,
+    parentUrl,
+    pages,
+  }
+}
+
+const getTableOfContentsFromContent = ({
+  content,
+}: Pick<ContentPageSchema, "content">) => {
+  const tableOfContents = content
+    .filter((block) => block.type === "heading" && block.level === 2)
+    .map((block: any) => ({
+      content: block.content,
+      anchorLink: "#" + block.id,
+    }))
+  return { items: tableOfContents }
+}
+
 const ContentLayout = ({
   site,
   page,
   content,
   LinkComponent,
 }: ContentPageSchema) => {
+  const sideRail = getSiderailFromSiteMap(
+    site.siteMap,
+    page.permalink.split("/").slice(1),
+  )
+  const tableOfContents = getTableOfContentsFromContent({ content })
+  const breadcrumb = getBreadcrumbFromSiteMap(
+    site.siteMap,
+    page.permalink.split("/").slice(1),
+  )
   return (
-    <Skeleton site={site} page={page}>
-      <div className="lg:hidden">
-        {page.sideRail && <Siderail {...page.sideRail} />}
-      </div>
+    <Skeleton site={site} page={page} LinkComponent={LinkComponent}>
+      <div className="lg:hidden">{sideRail && <Siderail {...sideRail} />}</div>
       <ContentPageHeader
         {...page.contentPageHeader}
+        title={page.title}
+        breadcrumb={breadcrumb}
         LinkComponent={LinkComponent}
       />
       <div className="flex gap-[120px] px-6 md:px-10 py-16 max-w-[1240px] mx-auto justify-center">
-        {page.sideRail && (
+        {sideRail && (
           <div className="hidden lg:block w-full max-w-[240px]">
-            <Siderail {...page.sideRail} LinkComponent={LinkComponent} />
+            <Siderail {...sideRail} LinkComponent={LinkComponent} />
           </div>
         )}
         <div className="flex flex-col gap-[90px] w-full max-w-[800px]">
-          <TableOfContents {...page.tableOfContents} />
+          {tableOfContents.items.length > 0 && (
+            <TableOfContents {...tableOfContents} />
+          )}
           <div>
             {content.map((component) =>
               renderComponent({ component, LinkComponent }),

--- a/src/templates/next/layouts/Content/Content.tsx
+++ b/src/templates/next/layouts/Content/Content.tsx
@@ -86,9 +86,9 @@ const getSiderailFromSiteMap = (
   }
 }
 
-const getTableOfContentsFromContent = ({
-  content,
-}: Pick<ContentPageSchema, "content">) => {
+const getTableOfContentsFromContent = (
+  content: ContentPageSchema["content"],
+) => {
   const items = []
   for (const block of content) {
     if (block.type === "heading" && block.level === 2) {
@@ -111,14 +111,18 @@ const ContentLayout = ({
     site.siteMap,
     page.permalink.split("/").slice(1),
   )
-  const tableOfContents = getTableOfContentsFromContent({ content })
+  const tableOfContents = getTableOfContentsFromContent(content)
   const breadcrumb = getBreadcrumbFromSiteMap(
     site.siteMap,
     page.permalink.split("/").slice(1),
   )
   return (
     <Skeleton site={site} page={page} LinkComponent={LinkComponent}>
-      <div className="lg:hidden">{sideRail && <Siderail {...sideRail} />}</div>
+      {sideRail && (
+        <div className="lg:hidden">
+          <Siderail {...sideRail} LinkComponent={LinkComponent} />
+        </div>
+      )}
       <ContentPageHeader
         {...page.contentPageHeader}
         title={page.title}

--- a/src/templates/next/layouts/Homepage/Homepage.stories.tsx
+++ b/src/templates/next/layouts/Homepage/Homepage.stories.tsx
@@ -21,7 +21,7 @@ Default.args = {
   layout: "homepage",
   site: {
     siteName: "Isomer Next",
-    siteMap: [],
+    siteMap: { title: "Home", permalink: "/", children: [] },
     theme: "isomer-next",
     isGovernment: true,
     logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
@@ -34,6 +34,7 @@ Default.args = {
     lastUpdated: "1 Jan 2021",
   },
   page: {
+    permalink: "/",
     title: "Home page",
     description: "A Next.js starter for Isomer",
   },

--- a/src/templates/next/layouts/Homepage/Homepage.tsx
+++ b/src/templates/next/layouts/Homepage/Homepage.tsx
@@ -9,7 +9,7 @@ const HomepageLayout = ({
   LinkComponent,
 }: HomePageSchema) => {
   return (
-    <Skeleton site={site} page={page}>
+    <Skeleton site={site} page={page} LinkComponent={LinkComponent}>
       <div
         // ComponentContent = "component-content" (customCssClass.ts) is imported by all Homepage components,
         // but cannot be used here as tailwind does not support dynamic class names


### PR DESCRIPTION
Mainly adds auto gen of content layout components such as breadcrumb and siderail
Remove sideRail and toc props from content layout as they will be computed directly in the layout from the sitemap
Fix type of sitemap

https://github.com/isomerpages/isomer-next-build/pull/1

see these for new usage of pkg:
https://github.com/isomerpages/isomer-next-base-template/pull/2
https://github.com/isomerpages/mti-corp/pull/1