### PR TITLE
Fix/remove indentation

### DIFF
--- a/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -27,7 +27,7 @@ const InfoCards = ({ cards, title, subtitle, variant }: InfoCardsProps) => {
     <section>
       {variant === "side" ? (
         <div
-          className={`${ComponentContent} py-12 px-5 lg:py-24 lg:px-10 flex flex-col lg:flex-row gap-12 items-center mx-auto`}
+          className={`${ComponentContent} py-12 lg:py-24 flex flex-col lg:flex-row gap-12 items-center mx-auto`}
         >
           <TitleSection
             title={title}
@@ -65,7 +65,7 @@ const InfoCards = ({ cards, title, subtitle, variant }: InfoCardsProps) => {
         </div>
       ) : (
         <div
-          className={`${ComponentContent} py-12 px-5 lg:py-24 lg:px-10 flex flex-col gap-12 items-center mx-auto`}
+          className={`${ComponentContent} py-12 lg:py-24 flex flex-col gap-12 items-center mx-auto`}
         >
           <TitleSection title={title} subtitle={subtitle} />
           <div

--- a/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -68,7 +68,7 @@ const InfoCols = ({
   const bgColor = backgroundColor === "gray" ? "bg-gray-100" : "bg-white"
   return (
     <section className={bgColor}>
-      <div className={`${ComponentContent} py-24 px-8 sm:px-16 lg:px-24`}>
+      <div className={`${ComponentContent} py-24`}>
         <div className="flex flex-col gap-12">
           <InfoColsHeader title={title} subtitle={subtitle} />
           <InfoBoxes infoBoxes={infoBoxes} LinkComponent={LinkComponent} />

--- a/src/templates/next/components/complex/Infobar/Infobar.tsx
+++ b/src/templates/next/components/complex/Infobar/Infobar.tsx
@@ -15,7 +15,7 @@ const Infobar = ({
   return (
     <section>
       <div
-        className={`${ComponentContent} flex flex-col gap-12 items-center mx-auto text-center lg:max-w-3xl px-5 py-16 lg:py-24`}
+        className={`${ComponentContent} flex flex-col gap-12 items-center mx-auto text-center lg:max-w-3xl py-16 lg:py-24`}
       >
         <div className="flex flex-col gap-7">
           <h1 className="text-content text-4xl leading-tight font-semibold lg:text-5xl lg:leading-tight">

--- a/src/templates/next/components/complex/Infopic/Infopic.tsx
+++ b/src/templates/next/components/complex/Infopic/Infopic.tsx
@@ -62,7 +62,7 @@ const SideBySideInfoPic = ({
       {/* Mobile-Tablet */}
       <div className="lg:hidden">
         <div
-          className={`${ComponentContent} py-16 sm:py-24 px-6 sm:px-14 flex flex-col gap-14`}
+          className={`${ComponentContent} py-16 sm:py-24 sm:px-14 flex flex-col gap-14`}
         >
           <TextComponent
             title={title}
@@ -78,7 +78,7 @@ const SideBySideInfoPic = ({
         <div
           className={`${ComponentContent} flex ${
             isTextOnRight ? "flex-row" : "flex-row-reverse"
-          } gap-14 px-10 py-24`}
+          } gap-14 py-24`}
         >
           <ImageComponent src={src} alt={alt} className="w-1/3" />
           <TextComponent
@@ -109,7 +109,7 @@ const SidePartInfoPic = ({
       <div className="lg:hidden">
         <div className="flex flex-col gap-0">
           <ImageComponent src={src} alt={alt} />
-          <div className={`${ComponentContent} py-10 px-6 sm:px-20`}>
+          <div className={`${ComponentContent} py-10`}>
             <TextComponent
               title={title}
               description={description}
@@ -124,7 +124,7 @@ const SidePartInfoPic = ({
         <div
           className={`${ComponentContent} flex ${
             isTextOnRight ? "flex-row" : "flex-row-reverse"
-          } gap-10 px-10`}
+          } gap-10`}
         >
           <ImageComponent src={src} alt={alt} className="w-1/2" />
           <div className="w-1/2 py-24 my-auto">

--- a/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -31,7 +31,7 @@ const KeyStatistics = ({ variant, title, statistics }: KeyStatisticsProps) => {
   return (
     <section>
       <div
-        className={`${ComponentContent} flex flex-col px-5 py-12 xs:px-10 xs:py-24 gap-10 ${
+        className={`${ComponentContent} flex flex-col py-12 xs:py-24 gap-10 ${
           variant === "side" ? "lg:flex-row lg:gap-16" : ""
         }`}
       >

--- a/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/src/templates/next/layouts/Content/Content.stories.tsx
@@ -840,6 +840,130 @@ Default.args = {
         },
       ],
     },
+    {
+      type: "infopic",
+      title:
+        "Explore your great neighbourhood with us can’t stretch all the way so this needs a max width",
+      description:
+        "They will try to close the door on you, just open it. Lion! The other day the grass was brown, now it’s green because I ain’t give up. Never surrender.",
+      imageAlt: "alt",
+      imageSrc: "https://placehold.co/200x200",
+      buttonLabel: "Primary CTA",
+      buttonUrl: "https://www.google.com",
+    },
+    {
+      type: "infobar",
+      title: "This is a place where you can put nice content",
+      description: "About a sentence worth of description here",
+      buttonLabel: "Primary CTA",
+      buttonUrl: "https://google.com",
+      secondaryButtonLabel: "Secondary CTA",
+      secondaryButtonUrl: "https://google.com",
+    },
+    {
+      type: "infocards",
+      title:
+        "Explore your great neighbourhood with us can’t stretch all the way so this needs a max width",
+      subtitle:
+        "They will try to close the door on you, just open it. Lion! The other day the grass was brown, now it’s green because I ain’t give up. Never surrender.",
+      variant: "top",
+      cards: [
+        {
+          title: "A yummy, tipsy evening at Duxton",
+          url: "https://www.google.com",
+          description:
+            "Explore Duxton with us and leave with a full belly, tipsy mind, and a happy smile.",
+          imageUrl: "https://placehold.co/200x300",
+          imageAlt: "alt text",
+          buttonLabel: "Explore with us",
+        },
+        {
+          title: "A yummy, tipsy evening at Duxton",
+          url: "https://www.google.com",
+          description:
+            "Explore Duxton with us and leave with a full belly, tipsy mind, and a happy smile. Explore Duxton with us and leave with a full belly, tipsy mind, and a happy smile. Explore Duxton with us and leave with a full belly, tipsy mind, and a happy smile.",
+          imageUrl: "https://placehold.co/200x300",
+          imageAlt: "alt text",
+          buttonLabel: "Explore with us",
+        },
+        {
+          title: "A yummy, tipsy evening at Duxton",
+          url: "https://www.google.com",
+          imageUrl: "https://placehold.co/200x300",
+          imageAlt: "alt text",
+          buttonLabel: "Explore with us",
+        },
+        {
+          title: "A yummy, tipsy evening at Duxton",
+          url: "https://www.google.com",
+          imageUrl: "https://placehold.co/200x300",
+          imageAlt: "alt text",
+          buttonLabel: "Explore with us",
+        },
+      ],
+    },
+    {
+      type: "infocols",
+      title: "Highlights",
+      subtitle: "Some of the things that we are working on",
+      infoBoxes: [
+        {
+          title: "Committee of Supply (COS) 2023",
+          description: "Building a Vibrant Economy, Nurturing Enterprises",
+          buttonLabel: "Read article",
+          buttonUrl: "/faq",
+          icon: "bar-chart",
+        },
+        {
+          title: "Committee of Supply (COS) 2023",
+          description: "Building a Vibrant Economy, Nurturing Enterprises",
+          buttonLabel: "Read article",
+          buttonUrl: "https://google.com",
+          icon: "bar-chart",
+        },
+        {
+          title: "Committee of Supply (COS) 2023",
+          description: "Building a Vibrant Economy, Nurturing Enterprises",
+          buttonLabel: "Read article",
+          buttonUrl: "/faq",
+          icon: "bar-chart",
+        },
+        {
+          title: "Committee of Supply (COS) 2023",
+          description: "Building a Vibrant Economy, Nurturing Enterprises",
+          buttonLabel: "Read article",
+          buttonUrl: "https://google.com",
+          icon: "bar-chart",
+        },
+        {
+          title: "Committee of Supply (COS) 2023",
+          description: "Building a Vibrant Economy, Nurturing Enterprises",
+          buttonLabel: "Read article",
+          buttonUrl: "/faq",
+          icon: "bar-chart",
+        },
+        {
+          title: "Committee of Supply (COS) 2023",
+          description: "Building a Vibrant Economy, Nurturing Enterprises",
+          buttonLabel: "Read article",
+          buttonUrl: "https://google.com",
+          icon: "bar-chart",
+        },
+      ],
+    },
+    {
+      type: "keystatistics",
+      variant: "side",
+      title: "Key economic indicators",
+      statistics: [
+        {
+          label: "Advance GDP Estimates, 4Q 2023 (YoY)",
+          value: "+2.8%",
+        },
+        { label: "Total Merchandise Trade, Dec 2023 (YoY)", value: "-6.8%" },
+        { label: "Industrial Production, Dec 2023 (YoY)", value: "-2.5%" },
+      ],
+    },
   ],
 }
 


### PR DESCRIPTION
This PR removes indentation for components which were originally built for homepage when used on content pages. As the Homepage layout has styles for the horizontal padding for `ComponentContent` class, the individual component `px-` values are being overridden for homepage, and are unneeded for content pages - as such, they have been removed.

These components have also been added to the storybook for the content layout.